### PR TITLE
Improve published rendering, asset finalization, and content refresh reliability

### DIFF
--- a/apps/node/src/_tests/asset-upload-integration.test.ts
+++ b/apps/node/src/_tests/asset-upload-integration.test.ts
@@ -127,6 +127,7 @@ describe('Asset Upload Integration - With Validation', () => {
   });
 
   it('should accept an oversized source image when the optimized output fits the size limit', async () => {
+    const reducedMaxSizeBytes = 1024;
     const storage = new AssetsFileSystemStorage(tmpAssetsRoot);
     const validator = new FileTypeAssetValidator(undefined);
     const optimizer: ImageOptimizerPort = {
@@ -136,7 +137,7 @@ describe('Asset Upload Integration - With Validation', () => {
         format: 'webp',
         originalFilename: 'maps/Ektaron.png',
         optimizedFilename: 'maps/Ektaron.webp',
-        originalSize: 6 * 1024 * 1024,
+        originalSize: 2048,
         optimizedSize: Buffer.from('optimized-webp').length,
         width: 100,
         height: 100,
@@ -149,13 +150,13 @@ describe('Asset Upload Integration - With Validation', () => {
       undefined,
       undefined,
       validator,
-      maxSizeBytes,
+      reducedMaxSizeBytes,
       optimizer
     );
 
     const oversizedPng = Buffer.concat([
       Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
-      Buffer.alloc(6 * 1024 * 1024),
+      Buffer.alloc(2048),
     ]);
 
     const result = await handler.handle({

--- a/apps/node/src/_tests/asset-upload-integration.test.ts
+++ b/apps/node/src/_tests/asset-upload-integration.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { UploadAssetsHandler } from '@core-application';
-import { type Asset } from '@core-domain';
+import { type Asset, type ImageOptimizerPort } from '@core-domain';
 
 import { AssetsFileSystemStorage } from '../infra/filesystem/assets-file-system.storage';
 import { FileTypeAssetValidator } from '../infra/validation/file-type-asset-validator';
@@ -124,6 +124,62 @@ describe('Asset Upload Integration - With Validation', () => {
     expect(result.errors).toBeDefined();
     expect(result.errors?.length).toBe(1);
     expect(result.errors?.[0].message).toMatch(/exceeds maximum allowed/);
+  });
+
+  it('should accept an oversized source image when the optimized output fits the size limit', async () => {
+    const storage = new AssetsFileSystemStorage(tmpAssetsRoot);
+    const validator = new FileTypeAssetValidator(undefined);
+    const optimizer: ImageOptimizerPort = {
+      isOptimizable: jest.fn().mockReturnValue(true),
+      optimize: jest.fn().mockResolvedValue({
+        data: new Uint8Array(Buffer.from('optimized-webp')),
+        format: 'webp',
+        originalFilename: 'maps/Ektaron.png',
+        optimizedFilename: 'maps/Ektaron.webp',
+        originalSize: 6 * 1024 * 1024,
+        optimizedSize: Buffer.from('optimized-webp').length,
+        width: 100,
+        height: 100,
+        wasOptimized: true,
+      }),
+      getConfig: jest.fn(),
+    };
+    handler = new UploadAssetsHandler(
+      storage,
+      undefined,
+      undefined,
+      validator,
+      maxSizeBytes,
+      optimizer
+    );
+
+    const oversizedPng = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.alloc(6 * 1024 * 1024),
+    ]);
+
+    const result = await handler.handle({
+      sessionId: 'test-session',
+      assets: [
+        {
+          relativePath: 'maps/Ektaron.png',
+          vaultPath: 'vault/maps/Ektaron.png',
+          fileName: 'Ektaron.png',
+          mimeType: 'image/png',
+          contentBase64: oversizedPng.toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.published).toBe(1);
+    expect(result.errors).toBeUndefined();
+    expect(result.renamedAssets).toEqual({
+      'maps/Ektaron.png': 'maps/Ektaron.webp',
+    });
+
+    const savedPath = path.join(tmpAssetsRoot, 'maps', 'Ektaron.webp');
+    const savedContent = await fs.readFile(savedPath);
+    expect(savedContent).toEqual(Buffer.from('optimized-webp'));
   });
 
   it('should handle batch upload with mixed valid/invalid assets', async () => {

--- a/apps/node/src/_tests/cache-headers.test.ts
+++ b/apps/node/src/_tests/cache-headers.test.ts
@@ -37,12 +37,11 @@ describe('Cache Headers Strategy', () => {
     // Create minimal Express app with cache strategy
     app = express();
 
-    // Assets with aggressive caching (immutable)
+    // Assets with moderate caching (revalidated via ?cv=)
     app.use(
       '/assets',
       express.static(testAssetsRoot, {
-        maxAge: '365d',
-        immutable: true,
+        maxAge: '7d',
         etag: true,
       })
     );
@@ -138,13 +137,13 @@ describe('Cache Headers Strategy', () => {
     });
   });
 
-  describe('/assets/* - Immutable Aggressive Caching', () => {
-    it('should return 200 with 1-year cache and immutable directive', async () => {
+  describe('/assets/* - Moderate Caching with ETag', () => {
+    it('should return 200 with 7-day cache and ETag', async () => {
       const res = await request(app).get('/assets/test-image.png');
 
       expect(res.status).toBe(200);
-      expect(res.headers['cache-control']).toContain('max-age=31536000'); // 365 days in seconds
-      expect(res.headers['cache-control']).toContain('immutable');
+      expect(res.headers['cache-control']).toContain('max-age=604800'); // 7 days in seconds
+      expect(res.headers['cache-control']).not.toContain('immutable');
       expect(res.headers['etag']).toBeDefined();
     });
 
@@ -159,7 +158,7 @@ describe('Cache Headers Strategy', () => {
   });
 
   describe('Cache Strategy Comparison', () => {
-    it('should have different max-age for manifest (60s) vs HTML (300s) vs assets (365d)', async () => {
+    it('should have different max-age for manifest (60s) vs HTML (300s) vs assets (7d)', async () => {
       const manifestRes = await request(app).get('/content/_manifest.json');
       const htmlRes = await request(app).get('/content/test-page.html');
       const assetRes = await request(app).get('/assets/test-image.png');
@@ -170,18 +169,19 @@ describe('Cache Headers Strategy', () => {
       // HTML: 300s (5 minutes)
       expect(htmlRes.headers['cache-control']).toContain('max-age=300');
 
-      // Assets: 31536000s (365 days)
-      expect(assetRes.headers['cache-control']).toContain('max-age=31536000');
+      // Assets: 604800s (7 days)
+      expect(assetRes.headers['cache-control']).toContain('max-age=604800');
     });
 
-    it('should enforce must-revalidate on content but not on immutable assets', async () => {
+    it('should enforce must-revalidate on content and use ETag for assets', async () => {
       const manifestRes = await request(app).get('/content/_manifest.json');
       const htmlRes = await request(app).get('/content/test-page.html');
       const assetRes = await request(app).get('/assets/test-image.png');
 
       expect(manifestRes.headers['cache-control']).toContain('must-revalidate');
       expect(htmlRes.headers['cache-control']).toContain('must-revalidate');
-      expect(assetRes.headers['cache-control']).toContain('immutable'); // immutable = never revalidate
+      expect(assetRes.headers['cache-control']).not.toContain('immutable');
+      expect(assetRes.headers['etag']).toBeDefined();
     });
   });
 });

--- a/apps/node/src/_tests/leaflet-assets-republication.integration.test.ts
+++ b/apps/node/src/_tests/leaflet-assets-republication.integration.test.ts
@@ -6,7 +6,7 @@ import { CreateSessionHandler, UploadAssetsHandler, UploadNotesHandler } from '@
 import { NoteHashService } from '@core-application/publishing/services/note-hash.service';
 import { DetectAssetsService } from '@core-application/vault-parsing/services/detect-assets.service';
 import { DetectLeafletBlocksService } from '@core-application/vault-parsing/services/detect-leaflet-blocks.service';
-import type { ImageOptimizerPort, LoggerPort, Manifest, PublishableNote } from '@core-domain';
+import type { ImageOptimizerPort, LoggerPort, PublishableNote } from '@core-domain';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 
 import { AssetsFileSystemStorage } from '../infra/filesystem/assets-file-system.storage';

--- a/apps/node/src/_tests/leaflet-assets-republication.integration.test.ts
+++ b/apps/node/src/_tests/leaflet-assets-republication.integration.test.ts
@@ -1,0 +1,361 @@
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { CreateSessionHandler, UploadAssetsHandler, UploadNotesHandler } from '@core-application';
+import { NoteHashService } from '@core-application/publishing/services/note-hash.service';
+import { DetectAssetsService } from '@core-application/vault-parsing/services/detect-assets.service';
+import { DetectLeafletBlocksService } from '@core-application/vault-parsing/services/detect-leaflet-blocks.service';
+import type { ImageOptimizerPort, LoggerPort, Manifest, PublishableNote } from '@core-domain';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+
+import { AssetsFileSystemStorage } from '../infra/filesystem/assets-file-system.storage';
+import { FileSystemSessionRepository } from '../infra/filesystem/file-system-session.repository';
+import { ManifestFileSystem } from '../infra/filesystem/manifest-file-system';
+import { NotesFileSystemStorage } from '../infra/filesystem/notes-file-system.storage';
+import { SessionNotesFileStorage } from '../infra/filesystem/session-notes-file.storage';
+import { StagingManager } from '../infra/filesystem/staging-manager';
+import { CalloutRendererService } from '../infra/markdown/callout-renderer.service';
+import { MarkdownItRenderer } from '../infra/markdown/markdown-it.renderer';
+import { SessionFinalizerService } from '../infra/sessions/session-finalizer.service';
+import { AssetHashService } from '../infra/utils/asset-hash.service';
+
+class NullLogger implements LoggerPort {
+  private currentLevel = 4;
+
+  set level(level: number) {
+    this.currentLevel = level;
+  }
+
+  get level(): number {
+    return this.currentLevel;
+  }
+
+  child(): LoggerPort {
+    return this;
+  }
+  debug(): void {}
+  info(): void {}
+  warn(): void {}
+  error(): void {}
+}
+
+class SequentialIdGenerator {
+  private current = 0;
+
+  generateId(): string {
+    this.current += 1;
+    return `session-${this.current}`;
+  }
+}
+
+function createSourceNote(): PublishableNote {
+  return {
+    noteId: 'ektaron-note',
+    title: 'Ektaron',
+    vaultPath: 'Ektaron/Ektaron.md',
+    relativePath: 'Ektaron/Ektaron.md',
+    content: [
+      '## Carte',
+      '',
+      '```leaflet',
+      'id: Ektaron-map',
+      'image: [[Ektaron.png]]',
+      'height: 700px',
+      'scale: 1365',
+      '```',
+    ].join('\n'),
+    frontmatter: {
+      flat: {},
+      nested: {},
+      tags: [],
+    },
+    folderConfig: {
+      id: 'folder-1',
+      vaultFolder: 'Ektaron',
+      routeBase: '/worlds',
+      vpsId: 'vps-1',
+      ignoredCleanupRuleIds: [],
+    },
+    routing: {
+      slug: 'ektaron',
+      path: '/worlds',
+      fullPath: '/worlds/ektaron',
+      routeBase: '/worlds',
+    },
+    eligibility: {
+      isPublishable: true,
+    },
+    publishedAt: new Date('2026-03-16T10:00:00.000Z'),
+    resolvedWikilinks: [],
+  };
+}
+
+function createParsedNote(logger: LoggerPort): PublishableNote {
+  return new DetectAssetsService(logger).process(
+    new DetectLeafletBlocksService(logger).process([createSourceNote()])
+  )[0];
+}
+
+function createOptimizer(webpBytes: Buffer): ImageOptimizerPort {
+  return {
+    isOptimizable: jest.fn().mockReturnValue(true),
+    optimize: jest.fn().mockResolvedValue({
+      data: new Uint8Array(webpBytes),
+      format: 'webp',
+      originalFilename: 'Ektaron.png',
+      optimizedFilename: 'Ektaron.webp',
+      originalSize: 1024,
+      optimizedSize: webpBytes.length,
+      width: 100,
+      height: 100,
+      wasOptimized: true,
+    }),
+    getConfig: jest.fn().mockReturnValue({
+      enabled: true,
+      convertToWebp: true,
+      quality: 85,
+      maxWidth: 4096,
+      maxHeight: 4096,
+      maxSizeBytes: 10 * 1024 * 1024,
+      preserveFormat: false,
+    }),
+  };
+}
+
+function routeToHtmlPath(root: string, route: string): string {
+  const segments = route.split('/').filter(Boolean);
+  const fileName = `${segments[segments.length - 1]}.html`;
+  return path.join(root, ...segments.slice(0, -1), fileName);
+}
+
+describe('Leaflet asset republication integration', () => {
+  let tempDir: string;
+  let contentRoot: string;
+  let assetsRoot: string;
+  let sessionsRoot: string;
+  let logger: LoggerPort;
+  let stagingManager: StagingManager;
+  let sessionRepository: FileSystemSessionRepository;
+  let productionManifestStorage: ManifestFileSystem;
+  let createSessionHandler: CreateSessionHandler;
+  let uploadNotesHandler: UploadNotesHandler;
+  let uploadAssetsHandler: UploadAssetsHandler;
+  let sessionFinalizer: SessionFinalizerService;
+  let assetHasher: AssetHashService;
+  let pngBytes: Buffer;
+  let webpBytes: Buffer;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'leaflet-assets-'));
+    contentRoot = path.join(tempDir, 'content');
+    assetsRoot = path.join(tempDir, 'assets');
+    sessionsRoot = path.join(tempDir, 'sessions');
+
+    await fs.mkdir(contentRoot, { recursive: true });
+    await fs.mkdir(assetsRoot, { recursive: true });
+    await fs.mkdir(sessionsRoot, { recursive: true });
+
+    logger = new NullLogger();
+    pngBytes = Buffer.from('raw-png-bytes');
+    webpBytes = Buffer.from('optimized-webp-bytes');
+
+    stagingManager = new StagingManager(contentRoot, assetsRoot, logger);
+    sessionRepository = new FileSystemSessionRepository(sessionsRoot);
+    productionManifestStorage = new ManifestFileSystem(contentRoot, logger);
+    assetHasher = new AssetHashService();
+
+    const sessionNotesStorage = new SessionNotesFileStorage(contentRoot, logger);
+    const markdownRenderer = new MarkdownItRenderer(new CalloutRendererService(), logger);
+
+    createSessionHandler = new CreateSessionHandler(
+      new SequentialIdGenerator(),
+      sessionRepository,
+      productionManifestStorage,
+      logger
+    );
+
+    uploadNotesHandler = new UploadNotesHandler(
+      markdownRenderer,
+      (sessionId) =>
+        new NotesFileSystemStorage(stagingManager.contentStagingPath(sessionId), logger),
+      (sessionId) => new ManifestFileSystem(stagingManager.contentStagingPath(sessionId), logger),
+      logger,
+      sessionNotesStorage,
+      undefined,
+      new NoteHashService()
+    );
+
+    uploadAssetsHandler = new UploadAssetsHandler(
+      (sessionId) =>
+        new AssetsFileSystemStorage(stagingManager.assetsStagingPath(sessionId), logger),
+      (sessionId) => new ManifestFileSystem(stagingManager.contentStagingPath(sessionId), logger),
+      assetHasher,
+      undefined,
+      undefined,
+      createOptimizer(webpBytes),
+      logger
+    );
+
+    sessionFinalizer = new SessionFinalizerService(
+      sessionNotesStorage,
+      stagingManager,
+      markdownRenderer,
+      (sessionId) =>
+        new NotesFileSystemStorage(stagingManager.contentStagingPath(sessionId), logger),
+      (sessionId) => new ManifestFileSystem(stagingManager.contentStagingPath(sessionId), logger),
+      sessionRepository,
+      logger
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('publishes a Leaflet image overlay coherently across two publications', async () => {
+    const route = '/worlds/ektaron';
+    const finalAssetPath = path.join(assetsRoot, 'Ektaron.webp');
+
+    const publishOnce = async () => {
+      const parsedNote = createParsedNote(logger);
+      const createResult = await createSessionHandler.handle({
+        notesPlanned: 1,
+        assetsPlanned: 1,
+        batchConfig: {
+          maxBytesPerRequest: 1024 * 1024,
+        },
+      });
+
+      const sessionId = createResult.sessionId;
+      const stagingManifestStorage = new ManifestFileSystem(
+        stagingManager.contentStagingPath(sessionId),
+        logger
+      );
+
+      await uploadNotesHandler.handle({
+        sessionId,
+        notes: [parsedNote],
+      });
+
+      const preAssetsManifest = await stagingManifestStorage.load();
+
+      const uploadResult = await uploadAssetsHandler.handle({
+        sessionId,
+        assets: [
+          {
+            relativePath: 'Ektaron.png',
+            vaultPath: '_assets/Ektaron.png',
+            fileName: 'Ektaron.png',
+            mimeType: 'image/png',
+            contentBase64: pngBytes.toString('base64'),
+          },
+        ],
+      });
+
+      const session = await sessionRepository.findById(sessionId);
+      if (session && uploadResult.renamedAssets) {
+        await sessionRepository.save({
+          ...session,
+          assetPathMappings: {
+            ...(session.assetPathMappings ?? {}),
+            ...uploadResult.renamedAssets,
+          },
+        });
+      }
+
+      const postAssetsManifest = await stagingManifestStorage.load();
+      await sessionFinalizer.rebuildFromStored(sessionId);
+      const postFinalizerManifest = await stagingManifestStorage.load();
+      const stagingRoute = postFinalizerManifest!.pages[0].route;
+      const stagingHtml = await fs.readFile(
+        routeToHtmlPath(stagingManager.contentStagingPath(sessionId), stagingRoute),
+        'utf8'
+      );
+
+      await stagingManager.promoteSession(
+        sessionId,
+        [route],
+        undefined,
+        undefined,
+        `${sessionId}-rev`
+      );
+
+      const finalManifest = await productionManifestStorage.load();
+      const finalHtml = await fs.readFile(
+        routeToHtmlPath(contentRoot, finalManifest!.pages[0].route),
+        'utf8'
+      );
+
+      return {
+        parsedNote,
+        createResult,
+        uploadResult,
+        preAssetsManifest,
+        postAssetsManifest,
+        postFinalizerManifest,
+        stagingHtml,
+        finalManifest,
+        finalHtml,
+      };
+    };
+
+    const firstPublication = await publishOnce();
+    const secondPublication = await publishOnce();
+
+    expect(firstPublication.parsedNote.leafletBlocks?.[0].imageOverlays?.[0].path).toBe(
+      'Ektaron.png'
+    );
+    expect(firstPublication.parsedNote.assets?.[0].target).toBe('Ektaron.png');
+    expect(firstPublication.createResult.existingAssetHashes).toBeUndefined();
+    expect(
+      firstPublication.preAssetsManifest?.pages[0].leafletBlocks?.[0].imageOverlays?.[0].path
+    ).toBe('Ektaron.png');
+    expect(firstPublication.uploadResult.published).toBe(1);
+    expect(firstPublication.uploadResult.skipped).toBeUndefined();
+    expect(firstPublication.uploadResult.renamedAssets).toEqual({
+      'Ektaron.png': 'Ektaron.webp',
+    });
+    expect(firstPublication.postAssetsManifest?.assets?.[0].path).toBe('Ektaron.webp');
+    expect(firstPublication.postFinalizerManifest?.assets).toBeUndefined();
+    expect(
+      firstPublication.postFinalizerManifest?.pages[0].leafletBlocks?.[0].imageOverlays?.[0].path
+    ).toBe('Ektaron.webp');
+    expect(firstPublication.finalManifest?.assets).toBeUndefined();
+
+    expect(secondPublication.parsedNote.leafletBlocks?.[0].imageOverlays?.[0].path).toBe(
+      'Ektaron.png'
+    );
+    expect(secondPublication.createResult.existingAssetHashes).toBeUndefined();
+    expect(
+      secondPublication.preAssetsManifest?.pages[0].leafletBlocks?.[0].imageOverlays?.[0].path
+    ).toBe('Ektaron.png');
+    expect(secondPublication.uploadResult.published).toBe(1);
+    expect(secondPublication.uploadResult.skipped).toBeUndefined();
+    expect(secondPublication.uploadResult.renamedAssets).toEqual({
+      'Ektaron.png': 'Ektaron.webp',
+    });
+    expect(secondPublication.postAssetsManifest?.assets?.[0].path).toBe('Ektaron.webp');
+    expect(secondPublication.postFinalizerManifest?.assets).toBeUndefined();
+    expect(
+      secondPublication.postFinalizerManifest?.pages[0].leafletBlocks?.[0].imageOverlays?.[0].path
+    ).toBe('Ektaron.webp');
+
+    expect(secondPublication.stagingHtml).toContain('data-leaflet-map-id="Ektaron-map"');
+    expect(secondPublication.stagingHtml).not.toContain('data-leaflet-block=');
+    expect(secondPublication.finalHtml).toContain('data-leaflet-map-id="Ektaron-map"');
+    expect(secondPublication.finalHtml).not.toContain('data-leaflet-block=');
+
+    expect(secondPublication.finalManifest?.assets).toBeUndefined();
+    expect(
+      secondPublication.finalManifest?.pages[0].leafletBlocks?.[0].imageOverlays?.[0].path
+    ).toBe('Ektaron.webp');
+
+    await expect(fs.access(finalAssetPath)).resolves.toBeUndefined();
+
+    const frontendUrl = `/assets/${encodeURI(
+      secondPublication.finalManifest!.pages[0].leafletBlocks![0].imageOverlays![0].path
+    )}`;
+    expect(frontendUrl).toBe('/assets/Ektaron.webp');
+  });
+});

--- a/apps/node/src/_tests/markdown-it-renderer.test.ts
+++ b/apps/node/src/_tests/markdown-it-renderer.test.ts
@@ -1,4 +1,5 @@
 import { type PublishableNote } from '@core-domain';
+import { load } from 'cheerio';
 
 import { MarkdownItRenderer } from '../infra/markdown/markdown-it.renderer';
 
@@ -30,6 +31,55 @@ describe('MarkdownItRenderer', () => {
     // Headings now have automatic IDs via markdown-it-anchor
     expect(html).toContain('<h1 id="title"');
     expect(html).toContain('>Title</h1>');
+  });
+
+  it('renders Obsidian $$...$$ math blocks with KaTeX HTML', async () => {
+    const renderer = new MarkdownItRenderer();
+    const note = baseNote();
+    note.content = ['Avant', '', '$$', 'E = mc^2', '$$', '', 'Apres'].join('\n');
+
+    const html = await renderer.render(note);
+    const $ = load(html);
+
+    expect($('.katex-display').length).toBe(1);
+    expect($('.katex-display').text()).toContain('E=mc2');
+    expect(html).not.toContain('$$');
+    expect(html).toContain('<p>Avant</p>');
+    expect(html).toContain('<p>Apres</p>');
+  });
+
+  it('renders \\textnormal expressions inside math blocks', async () => {
+    const renderer = new MarkdownItRenderer();
+    const note = baseNote();
+    note.content = [
+      '$$',
+      '\\textnormal{DD psionique} = 8 + \\textnormal{bonus de maîtrise} + \\textnormal{modificateur de caractéristique}',
+      '$$',
+    ].join('\n');
+
+    const html = await renderer.render(note);
+    const $ = load(html);
+    const mathText = $('.katex-display').text();
+
+    expect($('.katex-display').length).toBe(1);
+    expect(mathText).toContain('DD psionique');
+    expect(mathText).toContain('bonus de maîtrise');
+    expect(mathText).toContain('modificateur de caractéristique');
+    expect($('.katex-display .textrm').length).toBeGreaterThan(0);
+  });
+
+  it('renders inline $...$ math without affecting regular markdown', async () => {
+    const renderer = new MarkdownItRenderer();
+    const note = baseNote();
+    note.content = 'La formule $E = mc^2$ reste inline dans un paragraphe.';
+
+    const html = await renderer.render(note);
+    const $ = load(html);
+
+    expect($('.katex').length).toBeGreaterThan(0);
+    expect($('.katex-display').length).toBe(0);
+    expect($('p').text()).toContain('La formule');
+    expect($('p').text()).toContain('reste inline dans un paragraphe.');
   });
 
   it('injects assets with display options', async () => {

--- a/apps/node/src/_tests/session-finalizer-asset-path-replacement.test.ts
+++ b/apps/node/src/_tests/session-finalizer-asset-path-replacement.test.ts
@@ -182,6 +182,19 @@ describe('SessionFinalizerService.replaceAssetPath', () => {
       '/assets/deep-image.webp'
     );
   });
+
+  it('should handle filenames with accents, spaces and parentheses', () => {
+    const specialMappings = {
+      'Île de France (carte).png': 'Île de France (carte).webp',
+      'château-plan.jpg': 'château-plan.webp',
+    };
+    expect(replaceAssetPath('Île de France (carte).png', specialMappings)).toBe(
+      'Île de France (carte).webp'
+    );
+    expect(replaceAssetPath('/assets/château-plan.jpg', specialMappings)).toBe(
+      '/assets/château-plan.webp'
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -336,6 +349,21 @@ describe('SessionFinalizerService.replaceAssetPathsInLeafletBlocks', () => {
     expect(result.content).toContain('BrocheCameleon.webp');
     expect(result.content).not.toContain('BrocheCameleon.png');
   });
+
+  it('should handle special characters in JSON-encoded overlay paths', () => {
+    const mappings = { 'Île du Nord.png': 'Île du Nord.webp' };
+    const leafletBlock = {
+      id: 'map-special',
+      imageOverlays: [{ path: '/assets/Île du Nord.png', topLeft: [0, 0], bottomRight: [1, 1] }],
+    };
+    const html = `<div data-leaflet-block='${JSON.stringify(leafletBlock)}'></div>`;
+
+    const result = replaceAssetPathsInLeafletBlocks(html, mappings, createFakeLogger());
+
+    expect(result.modified).toBe(true);
+    expect(result.content).toContain('Île du Nord.webp');
+    expect(result.content).not.toContain('Île du Nord.png');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -484,5 +512,75 @@ describe('SessionFinalizerService.replaceAssetPathsInManifestPages', () => {
     expect(overlays[0].path).toBe('/assets/Ektaron.webp');
     expect(overlays[1].path).toBe('/assets/map-image.webp');
     expect(overlays[2].path).toBe('/assets/unmatched.gif'); // unchanged
+  });
+
+  it('should not mutate manifest when mappings object is empty', () => {
+    const leafletBlock: LeafletBlock = {
+      id: 'stable-map',
+      imageOverlays: [{ path: '/assets/Ektaron.webp', topLeft: [0, 0], bottomRight: [1, 1] }],
+    };
+    const page = createManifestPage({
+      coverImage: '/assets/cover.webp',
+      leafletBlocks: [leafletBlock],
+    });
+    const manifest = createManifest([page]);
+
+    const result = replaceAssetPathsInManifestPages(manifest, {}, createFakeLogger());
+
+    expect(result.modified).toBe(false);
+    expect(result.pagesModified).toBe(0);
+    expect(manifest.pages[0].coverImage).toBe('/assets/cover.webp');
+    expect((manifest.pages[0].leafletBlocks![0] as LeafletBlock).imageOverlays![0].path).toBe(
+      '/assets/Ektaron.webp'
+    );
+  });
+
+  it('should update overlay paths on republication with dedup-produced mapping', () => {
+    // Scenario: user republishes a page with a Leaflet map. The map overlay
+    // was originally Ektaron.png, optimised to Ektaron.webp in a previous
+    // session. On republication the asset is dedup-skipped and the handler
+    // produces renamedAssets = { 'Ektaron.png': 'Ektaron.webp' }.
+    // The manifest must NOT retain the old .png extension after finalisation.
+    const leafletBlock: LeafletBlock = {
+      id: 'world-map',
+      imageOverlays: [{ path: 'Ektaron.png', topLeft: [100, 0], bottomRight: [0, 100] }],
+    };
+    const page = createManifestPage({
+      title: 'Carte du monde',
+      leafletBlocks: [leafletBlock],
+    });
+    const manifest = createManifest([page]);
+
+    const dedupMapping = { 'Ektaron.png': 'Ektaron.webp' };
+
+    const result = replaceAssetPathsInManifestPages(manifest, dedupMapping, createFakeLogger());
+
+    expect(result.modified).toBe(true);
+    expect(result.leafletOverlaysUpdated).toBe(1);
+    expect((manifest.pages[0].leafletBlocks![0] as LeafletBlock).imageOverlays![0].path).toBe(
+      'Ektaron.webp'
+    );
+  });
+
+  it('should replace overlay paths containing accents, spaces and parentheses', () => {
+    const leafletBlock: LeafletBlock = {
+      id: 'map-accented',
+      imageOverlays: [
+        { path: '/assets/Île de France (carte).png', topLeft: [0, 0], bottomRight: [1, 1] },
+      ],
+    };
+    const page = createManifestPage({ leafletBlocks: [leafletBlock] });
+    const manifest = createManifest([page]);
+
+    const specialMappings = {
+      'Île de France (carte).png': 'Île de France (carte).webp',
+    };
+
+    const result = replaceAssetPathsInManifestPages(manifest, specialMappings, createFakeLogger());
+
+    expect(result.modified).toBe(true);
+    expect((manifest.pages[0].leafletBlocks![0] as LeafletBlock).imageOverlays![0].path).toBe(
+      '/assets/Île de France (carte).webp'
+    );
   });
 });

--- a/apps/node/src/_tests/validate-links.service.test.ts
+++ b/apps/node/src/_tests/validate-links.service.test.ts
@@ -234,6 +234,69 @@ describe('ValidateLinksService', () => {
       expect(fixedHtml).toContain('href="/lore/classes/barbarian"');
     });
 
+    it('should convert dataview wikilink spans to resolved anchors during finish validation', async () => {
+      const manifest = createMockManifest();
+
+      const html = `
+        <html>
+          <body>
+            <div class="markdown-body">
+              <p>See also: <span class="wikilink" data-wikilink="Yalgranthir/Yalgranthir">Yalgranthir</span></p>
+            </div>
+          </body>
+        </html>
+      `;
+
+      const htmlPath = path.join(tempDir, 'test.html');
+      await fs.writeFile(htmlPath, html, 'utf-8');
+
+      const result = await service.validateAllLinks(tempDir, manifest);
+
+      expect(result.filesProcessed).toBe(1);
+      expect(result.filesModified).toBe(1);
+
+      const fixedHtml = await fs.readFile(htmlPath, 'utf-8');
+      const $ = cheerio.load(fixedHtml);
+      const $link = $('a.wikilink').first();
+
+      expect($link.length).toBe(1);
+      expect($link.attr('href')).toBe('/mundis/yalgranthir/yalgranthir');
+      expect($link.attr('data-wikilink')).toBe('Yalgranthir/Yalgranthir');
+      expect($link.text()).toBe('Yalgranthir');
+      expect($('span.wikilink').length).toBe(0);
+    });
+
+    it('should re-resolve unresolved wikilink spans when the final manifest contains the page', async () => {
+      const manifest = createMockManifest();
+
+      const html = `
+        <html>
+          <body>
+            <div class="markdown-body">
+              <p>
+                <span class="wikilink wikilink-unresolved" title="Page inconnue : Ektaron" data-wikilink="Ektaron.md">Ektaron</span>
+              </p>
+            </div>
+          </body>
+        </html>
+      `;
+
+      const htmlPath = path.join(tempDir, 'test.html');
+      await fs.writeFile(htmlPath, html, 'utf-8');
+
+      await service.validateAllLinks(tempDir, manifest);
+
+      const fixedHtml = await fs.readFile(htmlPath, 'utf-8');
+      const $ = cheerio.load(fixedHtml);
+      const $link = $('a.wikilink').first();
+
+      expect($link.length).toBe(1);
+      expect($link.attr('href')).toBe('/mundis/ektaron');
+      expect($link.attr('data-wikilink')).toBe('Ektaron');
+      expect($link.attr('class')).toBe('wikilink');
+      expect(fixedHtml).not.toContain('wikilink-unresolved');
+    });
+
     it('should recursively process nested directories', async () => {
       const manifest = createMockManifest();
 

--- a/apps/node/src/infra/http/express/app.ts
+++ b/apps/node/src/infra/http/express/app.ts
@@ -101,14 +101,13 @@ export function createApp(rootLogger?: LoggerPort) {
 
   // Note: Removed disableCache middleware (no longer needed after conditional caching implementation)
 
-  // Static assets with aggressive caching (immutable content)
+  // Static assets with moderate caching (revalidated via ?cv= query param)
   app.use(
     '/assets',
     express.static(EnvConfig.assetsRoot(), {
       etag: true,
       lastModified: true,
-      maxAge: '365d', // Cache assets for 1 year
-      immutable: true, // Assets never change
+      maxAge: '7d', // Cache assets for 7 days; frontend appends ?cv= for cache-busting
     })
   );
 

--- a/apps/node/src/infra/markdown/katex-renderer.plugin.ts
+++ b/apps/node/src/infra/markdown/katex-renderer.plugin.ts
@@ -1,0 +1,195 @@
+import type { KatexOptions } from 'katex';
+import katex from 'katex';
+import type MarkdownIt from 'markdown-it';
+
+type InlineState = MarkdownIt.StateInline;
+type BlockState = MarkdownIt.StateBlock;
+
+function isValidDollarDelimiter(
+  state: InlineState,
+  pos: number
+): {
+  canOpen: boolean;
+  canClose: boolean;
+} {
+  const prevChar = readCodePoint(state.src, pos - 1);
+  const nextChar = pos + 1 <= state.posMax ? readCodePoint(state.src, pos + 1) : -1;
+
+  let canOpen = true;
+  let canClose = true;
+
+  if (prevChar === 0x20 || prevChar === 0x09 || (nextChar >= 0x30 && nextChar <= 0x39)) {
+    canClose = false;
+  }
+
+  if (nextChar === 0x20 || nextChar === 0x09) {
+    canOpen = false;
+  }
+
+  return { canOpen, canClose };
+}
+
+function readCodePoint(value: string, index: number): number {
+  if (index < 0) {
+    return -1;
+  }
+
+  return value.codePointAt(index) ?? -1;
+}
+
+function appendPendingDollar(
+  state: InlineState,
+  silent: boolean,
+  pending: string,
+  nextPos: number
+) {
+  if (!silent) {
+    state.pending += pending;
+  }
+
+  state.pos = nextPos;
+  return true;
+}
+
+function findClosingInlineDollar(state: InlineState, start: number): number {
+  let match = start;
+
+  while ((match = state.src.indexOf('$', match)) !== -1) {
+    let backslashPos = match - 1;
+    while (state.src[backslashPos] === '\\') {
+      backslashPos -= 1;
+    }
+
+    // Odd number of backslashes means the delimiter is not escaped.
+    if ((match - backslashPos) % 2 === 1) {
+      return match;
+    }
+
+    match += 1;
+  }
+
+  return -1;
+}
+
+function hasTrimmedContent(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function mathInline(state: InlineState, silent: boolean): boolean {
+  if (state.src[state.pos] !== '$') {
+    return false;
+  }
+
+  const delimiter = isValidDollarDelimiter(state, state.pos);
+  if (!delimiter.canOpen) {
+    return appendPendingDollar(state, silent, '$', state.pos + 1);
+  }
+
+  const start = state.pos + 1;
+  const match = findClosingInlineDollar(state, start);
+
+  if (match === -1) {
+    return appendPendingDollar(state, silent, '$', start);
+  }
+
+  if (match - start === 0) {
+    return appendPendingDollar(state, silent, '$$', start + 1);
+  }
+
+  const closingDelimiter = isValidDollarDelimiter(state, match);
+  if (!closingDelimiter.canClose) {
+    return appendPendingDollar(state, silent, '$', start);
+  }
+
+  if (!silent) {
+    const token = state.push('math_inline', 'math', 0);
+    token.markup = '$';
+    token.content = state.src.slice(start, match);
+  }
+
+  state.pos = match + 1;
+  return true;
+}
+
+function mathBlock(state: BlockState, start: number, end: number, silent: boolean): boolean {
+  let pos = state.bMarks[start] + state.tShift[start];
+  let max = state.eMarks[start];
+
+  if (pos + 2 > max || state.src.slice(pos, pos + 2) !== '$$') {
+    return false;
+  }
+
+  pos += 2;
+  let firstLine = state.src.slice(pos, max);
+  let lastLine = '';
+  let next = start;
+  let found = false;
+
+  if (silent) {
+    return true;
+  }
+
+  const firstLineTrimmed = firstLine.trim();
+  if (firstLineTrimmed.endsWith('$$')) {
+    firstLine = firstLineTrimmed.slice(0, -2);
+    found = true;
+  }
+
+  while (!found) {
+    next += 1;
+
+    if (next >= end) {
+      break;
+    }
+
+    pos = state.bMarks[next] + state.tShift[next];
+    max = state.eMarks[next];
+
+    if (pos < max && state.tShift[next] < state.blkIndent) {
+      break;
+    }
+
+    if (state.src.slice(pos, max).trim().endsWith('$$')) {
+      const lastDelimiter = state.src.slice(0, max).lastIndexOf('$$');
+      lastLine = state.src.slice(pos, lastDelimiter);
+      found = true;
+    }
+  }
+
+  state.line = next + 1;
+
+  const token = state.push('math_block', 'math', 0);
+  token.block = true;
+  const firstLineContent = hasTrimmedContent(firstLine) ? `${firstLine}\n` : '';
+  const lastLineContent = hasTrimmedContent(lastLine) ? lastLine : '';
+  token.content =
+    firstLineContent + state.getLines(start + 1, next, state.tShift[start], true) + lastLineContent;
+  token.map = [start, state.line];
+  token.markup = '$$';
+
+  return true;
+}
+
+function renderMath(content: string, displayMode: boolean, options: KatexOptions): string {
+  return (
+    katex.renderToString(content, {
+      throwOnError: false,
+      trust: false,
+      output: 'htmlAndMathml',
+      ...options,
+      displayMode,
+    }) + (displayMode ? '\n' : '')
+  );
+}
+
+export function registerKatexRenderer(md: MarkdownIt, options: KatexOptions = {}): void {
+  md.inline.ruler.after('escape', 'math_inline', mathInline);
+  md.block.ruler.after('blockquote', 'math_block', mathBlock, {
+    alt: ['paragraph', 'reference', 'blockquote', 'list'],
+  });
+
+  md.renderer.rules['math_inline'] = (tokens, idx) =>
+    renderMath(tokens[idx].content, false, options);
+
+  md.renderer.rules['math_block'] = (tokens, idx) => renderMath(tokens[idx].content, true, options);
+}

--- a/apps/node/src/infra/markdown/markdown-it.renderer.ts
+++ b/apps/node/src/infra/markdown/markdown-it.renderer.ts
@@ -14,6 +14,7 @@ import footnote from 'markdown-it-footnote';
 
 import { CalloutRendererService } from './callout-renderer.service';
 import { HeadingSlugger } from './heading-slugger';
+import { registerKatexRenderer } from './katex-renderer.plugin';
 import { TagFilterService } from './tag-filter.service';
 
 export class MarkdownItRenderer implements MarkdownRendererPort {
@@ -42,6 +43,7 @@ export class MarkdownItRenderer implements MarkdownRendererPort {
       permalink: false, // Don't add permalink links
       level: [1, 2, 3, 4, 5, 6], // Add IDs to all heading levels
     });
+    registerKatexRenderer(this.md);
 
     this.calloutRenderer.register(this.md);
     this.customizeTableRenderer();

--- a/apps/node/src/infra/sessions/validate-links.service.ts
+++ b/apps/node/src/infra/sessions/validate-links.service.ts
@@ -109,7 +109,11 @@ export class ValidateLinksService {
   }
 
   /**
-   * Validate links within a single HTML document
+   * Validate links within a single HTML document.
+   *
+   * This pass is intentionally more permissive than the renderer:
+   * it can recover valid links from unresolved spans or Dataview-generated
+   * `data-wikilink` placeholders once the final manifest is complete.
    */
   private validateLinksInHtml(
     html: string,
@@ -120,53 +124,104 @@ export class ValidateLinksService {
     let linksProcessed = 0;
     let linksTransformed = 0;
 
-    // Find all <a> tags
     $('a').each((_, el) => {
       const $el = $(el);
       const href = $el.attr('href');
+      const dataWikilink = $el.attr('data-wikilink');
 
-      if (!href) {
-        return; // Skip links without href
+      if (!href && !dataWikilink) {
+        return;
       }
 
       linksProcessed++;
 
-      // Skip fragment-only links (#section) and external URLs
-      if (href.startsWith('#') || href.startsWith('http://') || href.startsWith('https://')) {
+      if (
+        href &&
+        (href.startsWith('#') || href.startsWith('http://') || href.startsWith('https://'))
+      ) {
         return;
       }
 
-      // Skip index routes (e.g., /arali/index, /ektaron/index) - they're valid folder indexes
-      if (href.endsWith('/index') || href === '/index') {
+      if (href && (href.endsWith('/index') || href === '/index')) {
         return;
       }
 
-      // Extract the base path without fragment for validation
-      // e.g., "/page#section" → "/page", but keep the fragment to preserve it if valid
-      const [basePath, fragment] = href.split('#');
-      const hrefToValidate = basePath || href;
+      const hrefResolution = href ? this.resolveLinkCandidate(href, pathMap) : undefined;
+      const wikilinkResolution = dataWikilink
+        ? this.resolveLinkCandidate(this.normalizeWikilinkTarget(dataWikilink), pathMap)
+        : undefined;
+      const resolved = hrefResolution?.page ? hrefResolution : wikilinkResolution;
 
-      // Try to resolve the link against the manifest
-      const resolved = this.resolveLinkPath(hrefToValidate, pathMap);
+      if (resolved?.page) {
+        const correctHref = resolved.fragment
+          ? `${resolved.page.route}#${resolved.fragment}`
+          : resolved.page.route;
 
-      if (resolved) {
-        // Valid link - update href to use proper routed path, preserving fragment if present
-        const correctHref = fragment ? `${resolved.route}#${fragment}` : resolved.route;
         if ($el.attr('href') !== correctHref) {
           $el.attr('href', correctHref);
           linksTransformed++;
         }
-      } else {
-        // Invalid link - transform to unresolved wikilink span
-        const linkText = $el.text() || href;
-        const title = `Page inconnue : ${linkText}`;
 
-        // Replace <a> with <span class="wikilink wikilink-unresolved">
-        $el.replaceWith(
-          `<span class="wikilink wikilink-unresolved" title="${this.escapeHtml(title)}">${this.escapeHtml(linkText)}</span>`
-        );
-        linksTransformed++;
+        if (dataWikilink) {
+          $el.attr('data-wikilink', this.normalizeWikilinkTarget(dataWikilink));
+        }
+
+        return;
       }
+
+      const linkText = $el.text() || href || dataWikilink || '';
+      const title = `Page inconnue : ${linkText}`;
+      const wikilinkTarget = this.normalizeWikilinkTarget(dataWikilink || href || linkText);
+
+      $el.replaceWith(
+        `<span class="wikilink wikilink-unresolved" title="${this.escapeHtml(title)}" data-wikilink="${this.escapeHtml(wikilinkTarget)}">${this.escapeHtml(linkText)}</span>`
+      );
+      linksTransformed++;
+    });
+
+    $('[data-wikilink]').each((_, el) => {
+      const $el = $(el);
+      if ($el.is('a')) {
+        return;
+      }
+
+      const rawTarget = $el.attr('data-wikilink');
+      if (!rawTarget) {
+        return;
+      }
+
+      linksProcessed++;
+
+      const normalizedTarget = this.normalizeWikilinkTarget(rawTarget);
+      if (!normalizedTarget) {
+        return;
+      }
+
+      const resolved = this.resolveLinkCandidate(normalizedTarget, pathMap);
+      if (!resolved.page) {
+        return;
+      }
+
+      const href = resolved.fragment
+        ? `${resolved.page.route}#${resolved.fragment}`
+        : resolved.page.route;
+      const classNames = ($el.attr('class') || '')
+        .split(/\s+/)
+        .filter(Boolean)
+        .filter((cls) => cls !== 'wikilink-unresolved');
+
+      if (!classNames.includes('wikilink')) {
+        classNames.push('wikilink');
+      }
+
+      const $anchor = $('<a></a>');
+      $anchor.attr('href', href);
+      $anchor.attr('data-wikilink', normalizedTarget);
+      $anchor.attr('class', classNames.join(' '));
+      $anchor.html($el.html() || this.escapeHtml($el.text()));
+
+      $el.replaceWith($anchor);
+      linksTransformed++;
     });
 
     if (linksTransformed > 0) {
@@ -176,7 +231,6 @@ export class ValidateLinksService {
       });
     }
 
-    // Return the updated HTML (cheerio might reformat slightly)
     return linksTransformed > 0 ? $.html() : html;
   }
 
@@ -200,7 +254,7 @@ export class ValidateLinksService {
     }
 
     // Otherwise, treat as vault path or partial vault path
-    let normalized = decodeURIComponent(href).toLowerCase();
+    const normalized = decodeURIComponent(href).toLowerCase();
 
     // Try exact match first
     let matched = pathMap.get(normalized);
@@ -226,11 +280,10 @@ export class ValidateLinksService {
         return page;
       }
 
-      // Check if href is a partial match (e.g., "Yalgranthir/Yalgranthir" matches "Ektaron/Yalgranthir/Yalgranthir")
+      // Check if href is a partial match
       const pathSegments = vaultPath.split('/').map((s) => s.toLowerCase());
       const hrefSegments = normalized.split('/');
 
-      // Check if all href segments match the end of the vault path
       if (hrefSegments.length > 0 && pathSegments.length >= hrefSegments.length) {
         const pathTail = pathSegments.slice(-hrefSegments.length);
         const match = hrefSegments.every((seg, i) => {
@@ -245,6 +298,23 @@ export class ValidateLinksService {
     }
 
     return undefined;
+  }
+
+  private resolveLinkCandidate(
+    rawValue: string,
+    pathMap: Map<string, ManifestPage>
+  ): { page?: ManifestPage; fragment?: string } {
+    const [basePath, fragment] = rawValue.split('#');
+    return {
+      page: this.resolveLinkPath(basePath || rawValue, pathMap),
+      fragment,
+    };
+  }
+
+  private normalizeWikilinkTarget(target: string): string {
+    return decodeURIComponent(target)
+      .replace(/\.md(?=#|$)/i, '')
+      .replace(/^\/+/, '');
   }
 
   /**

--- a/apps/obsidian-vps-publish/src/_tests/leaflet-asset-upload-chain.integration.test.ts
+++ b/apps/obsidian-vps-publish/src/_tests/leaflet-asset-upload-chain.integration.test.ts
@@ -2,8 +2,8 @@ import { DetectAssetsService } from '@core-application/vault-parsing/services/de
 import { DetectLeafletBlocksService } from '@core-application/vault-parsing/services/detect-leaflet-blocks.service';
 import type { LoggerPort, PublishableNote } from '@core-domain';
 
-import { AssetHashService } from '../lib/infra/crypto/asset-hash.service';
 import { AssetsUploaderAdapter } from '../lib/infra/assets-uploader.adapter';
+import { AssetHashService } from '../lib/infra/crypto/asset-hash.service';
 import { ObsidianAssetsVaultAdapter } from '../lib/infra/obsidian-assets-vault.adapter';
 
 class NullLogger implements LoggerPort {

--- a/apps/obsidian-vps-publish/src/_tests/leaflet-asset-upload-chain.integration.test.ts
+++ b/apps/obsidian-vps-publish/src/_tests/leaflet-asset-upload-chain.integration.test.ts
@@ -1,0 +1,129 @@
+import { DetectAssetsService } from '@core-application/vault-parsing/services/detect-assets.service';
+import { DetectLeafletBlocksService } from '@core-application/vault-parsing/services/detect-leaflet-blocks.service';
+import type { LoggerPort, PublishableNote } from '@core-domain';
+
+import { AssetHashService } from '../lib/infra/crypto/asset-hash.service';
+import { AssetsUploaderAdapter } from '../lib/infra/assets-uploader.adapter';
+import { ObsidianAssetsVaultAdapter } from '../lib/infra/obsidian-assets-vault.adapter';
+
+class NullLogger implements LoggerPort {
+  private currentLevel = 4;
+
+  set level(level: number) {
+    this.currentLevel = level;
+  }
+
+  get level(): number {
+    return this.currentLevel;
+  }
+
+  child(): LoggerPort {
+    return this;
+  }
+  debug(): void {}
+  info(): void {}
+  warn(): void {}
+  error(): void {}
+}
+
+function createSourceNote(): PublishableNote {
+  return {
+    noteId: 'ektaron-note',
+    title: 'Ektaron',
+    vaultPath: 'Ektaron/Ektaron.md',
+    relativePath: 'Ektaron/Ektaron.md',
+    content: [
+      '## Carte',
+      '',
+      '```leaflet',
+      'id: Ektaron-map',
+      'image: [[Ektaron.png]]',
+      'height: 700px',
+      'scale: 1365',
+      '```',
+    ].join('\n'),
+    frontmatter: {
+      flat: {},
+      nested: {},
+      tags: [],
+    },
+    folderConfig: {
+      id: 'folder-1',
+      vaultFolder: 'Ektaron',
+      routeBase: '/worlds',
+      vpsId: 'vps-1',
+      ignoredCleanupRuleIds: [],
+    },
+    routing: {
+      slug: 'ektaron',
+      path: '/worlds',
+      fullPath: '/worlds/ektaron',
+      routeBase: '/worlds',
+    },
+    eligibility: {
+      isPublishable: true,
+    },
+    publishedAt: new Date('2026-03-16T10:00:00.000Z'),
+    resolvedWikilinks: [],
+  };
+}
+
+describe('Leaflet asset upload chain (plugin side)', () => {
+  it('keeps Ektaron.png through parser/resolution and does not client-dedup against an optimized production hash', async () => {
+    const logger = new NullLogger();
+    const pngBytes = Buffer.from('raw-png-bytes');
+    const webpBytes = Buffer.from('optimized-webp-bytes');
+
+    const parsedNote = new DetectAssetsService(logger).process(
+      new DetectLeafletBlocksService(logger).process([createSourceNote()])
+    )[0];
+
+    expect(parsedNote.leafletBlocks?.[0].imageOverlays?.[0].path).toBe('Ektaron.png');
+    expect(parsedNote.assets?.[0].target).toBe('Ektaron.png');
+
+    const app = {
+      vault: {
+        getFiles: jest.fn().mockReturnValue([
+          {
+            path: '_assets/Ektaron.png',
+            name: 'Ektaron.png',
+          },
+        ]),
+        readBinary: jest.fn().mockResolvedValue(pngBytes),
+      },
+    } as any;
+
+    const vaultAdapter = new ObsidianAssetsVaultAdapter(app, logger);
+    const resolvedAssets = await vaultAdapter.resolveAssetsFromNotes([parsedNote], '_assets', true);
+
+    expect(resolvedAssets).toHaveLength(1);
+    expect(resolvedAssets[0].vaultPath).toBe('_assets/Ektaron.png');
+    expect(resolvedAssets[0].fileName).toBe('Ektaron.png');
+    expect(resolvedAssets[0].relativeAssetPath).toBe('Ektaron.png');
+
+    const sessionClient = {
+      uploadAssetChunk: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    const uploader = new AssetsUploaderAdapter(
+      sessionClient,
+      'session-2',
+      {
+        generateGuid: jest.fn().mockReturnValue('guid-1'),
+      },
+      new AssetHashService(),
+      logger,
+      1024,
+      undefined,
+      1,
+      [await new AssetHashService().computeHash(webpBytes)]
+    );
+
+    const apiAsset = await (uploader as any).buildApiAsset(resolvedAssets[0]);
+    expect(apiAsset.relativePath).toBe('Ektaron.png');
+
+    await uploader.upload(resolvedAssets);
+
+    expect(sessionClient.uploadAssetChunk).toHaveBeenCalled();
+  });
+});

--- a/apps/obsidian-vps-publish/src/i18n/locales.ts
+++ b/apps/obsidian-vps-publish/src/i18n/locales.ts
@@ -404,6 +404,7 @@ export type HelpTranslations = {
     wikilinks: HelpSection;
     assets: HelpSection;
     dataview: HelpSection;
+    math: HelpSection;
     leaflet: HelpSection;
     markdown: HelpSection;
   };
@@ -807,6 +808,21 @@ export const en: Translations = {
           {
             code: '```dataviewjs\nawait dv.view("my-view", {param: "value"})\n```',
             description: 'DataviewJS custom view',
+          },
+        ],
+      },
+      math: {
+        title: 'Math & LaTeX',
+        content:
+          'Math expressions are rendered server-side with KaTeX before publishing.\n\nSupported: block math with `$$ ... $$`. Inline math with `$...$` is also supported when used in normal text.\n\nThe published site only injects the generated HTML, so rendering stays compatible with SSR and hydration.',
+        examples: [
+          {
+            code: '$$\n\\textnormal{DD psionique} = 8 + \\textnormal{proficiency bonus} + \\textnormal{ability modifier}\n$$',
+            description: 'Display formula rendered as KaTeX before upload',
+          },
+          {
+            code: 'Energy: $E = mc^2$',
+            description: 'Inline math rendered in the surrounding paragraph',
           },
         ],
       },
@@ -1342,6 +1358,21 @@ export const fr: Translations = {
           {
             code: '```dataviewjs\nawait dv.view("ma-vue", {param: "valeur"})\n```',
             description: 'Vue personnalisée DataviewJS',
+          },
+        ],
+      },
+      math: {
+        title: 'Maths & LaTeX',
+        content:
+          "Les expressions mathématiques sont rendues côté serveur avec KaTeX avant publication.\n\nSupporté au minimum : les blocs `$$ ... $$`. Le mode inline `$...$` est aussi pris en charge lorsqu'il est utilisé dans du texte normal.\n\nLe site publié ne fait qu'injecter le HTML généré, ce qui reste compatible avec SSR et hydratation.",
+        examples: [
+          {
+            code: '$$\n\\textnormal{DD psionique} = 8 + \\textnormal{bonus de maîtrise} + \\textnormal{modificateur de caractéristique}\n$$',
+            description: 'Formule affichée en bloc et rendue en KaTeX avant upload',
+          },
+          {
+            code: 'Énergie : $E = mc^2$',
+            description: 'Math inline rendue dans le paragraphe courant',
           },
         ],
       },

--- a/apps/obsidian-vps-publish/src/lib/modals/help-modal.ts
+++ b/apps/obsidian-vps-publish/src/lib/modals/help-modal.ts
@@ -36,6 +36,7 @@ export class HelpModal extends Modal {
       { id: 'wikilinks', section: this.t.help.sections.wikilinks },
       { id: 'assets', section: this.t.help.sections.assets },
       { id: 'dataview', section: this.t.help.sections.dataview },
+      { id: 'math', section: this.t.help.sections.math },
       { id: 'leaflet', section: this.t.help.sections.leaflet },
       { id: 'markdown', section: this.t.help.sections.markdown },
     ];

--- a/apps/site/ngsw-config.json
+++ b/apps/site/ngsw-config.json
@@ -15,7 +15,7 @@
       "installMode": "lazy",
       "updateMode": "prefetch",
       "resources": {
-        "files": ["/assets/**", "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"]
+        "files": ["/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"]
       }
     }
   ],
@@ -55,7 +55,7 @@
       "urls": ["/assets/**"],
       "cacheConfig": {
         "maxSize": 500,
-        "maxAge": "365d",
+        "maxAge": "7d",
         "strategy": "freshness",
         "timeout": "10s"
       }

--- a/apps/site/src/_tests/catalog-facade.test.ts
+++ b/apps/site/src/_tests/catalog-facade.test.ts
@@ -1,4 +1,5 @@
 import { type Manifest, type ManifestRepository, Slug } from '@core-domain';
+import { Subject } from 'rxjs';
 
 import { CatalogFacade } from '../application/facades/catalog-facade';
 import type { ContentRepository } from '../domain/ports/content-repository.port';
@@ -23,15 +24,27 @@ describe('CatalogFacade', () => {
 
   let manifestRepo: jest.Mocked<ManifestRepository>;
   let contentRepo: jest.Mocked<ContentRepository>;
+  let versionChanged$: Subject<{ version: string; generatedAt: string }>;
+  let contentVersionService: {
+    versionChanged$: Subject<{ version: string; generatedAt: string }>;
+    checkVersion: jest.Mock<Promise<null>, []>;
+  };
 
   beforeEach(() => {
     manifestRepo = { load: jest.fn().mockResolvedValue(manifest) };
     contentRepo = { fetch: jest.fn().mockResolvedValue('<p>html</p>') };
+    versionChanged$ = new Subject<{ version: string; generatedAt: string }>();
+    contentVersionService = {
+      versionChanged$,
+      checkVersion: jest.fn().mockResolvedValue(null),
+    };
   });
 
   it('loads manifest on init and caches', async () => {
-    const facade = new CatalogFacade(manifestRepo, contentRepo);
+    const facade = new CatalogFacade(manifestRepo, contentRepo, contentVersionService);
     await Promise.resolve();
+    await Promise.resolve();
+    expect(contentVersionService.checkVersion).toHaveBeenCalledTimes(1);
     expect(manifestRepo.load).toHaveBeenCalledTimes(1);
 
     await facade.ensureManifest();
@@ -39,7 +52,8 @@ describe('CatalogFacade', () => {
   });
 
   it('searches and fetches html by slug', async () => {
-    const facade = new CatalogFacade(manifestRepo, contentRepo);
+    const facade = new CatalogFacade(manifestRepo, contentRepo, contentVersionService);
+    await Promise.resolve();
     await Promise.resolve();
 
     facade.query.set('start');
@@ -49,5 +63,42 @@ describe('CatalogFacade', () => {
     const html = await facade.getHtmlBySlugOrRoute('start');
     expect(html?.html).toContain('html');
     expect(contentRepo.fetch).toHaveBeenCalledWith('/docs/start');
+  });
+
+  it('reloads the manifest when content version changes', async () => {
+    const updatedManifest: Manifest = {
+      ...manifest,
+      pages: [
+        {
+          ...page,
+          route: '/ektaron',
+          title: 'Ektaron',
+          leafletBlocks: [
+            {
+              id: 'Ektaron-map',
+              imageOverlays: [{ path: 'Ektaron.webp' }],
+            },
+          ],
+        },
+      ],
+    };
+
+    manifestRepo.load.mockResolvedValueOnce(manifest).mockResolvedValueOnce(updatedManifest);
+
+    const facade = new CatalogFacade(manifestRepo, contentRepo, contentVersionService);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    versionChanged$.next({
+      version: 'new-version',
+      generatedAt: new Date().toISOString(),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(manifestRepo.load).toHaveBeenCalledTimes(2);
+    expect(facade.manifest().pages[0]?.leafletBlocks?.[0]?.imageOverlays?.[0]?.path).toBe(
+      'Ektaron.webp'
+    );
   });
 });

--- a/apps/site/src/_tests/leaflet-injection.service.test.ts
+++ b/apps/site/src/_tests/leaflet-injection.service.test.ts
@@ -349,14 +349,16 @@ describe('LeafletInjectionService', () => {
       expect(createSpy).toHaveBeenCalledWith(ph, BLOCK_A, fakeInjector, refs);
       expect(stats.found).toBe(1);
       expect(stats.created).toBe(1);
+      expect(stats.updated).toBe(0);
       expect(stats.active).toBe(1);
       expect(stats.ignored).toEqual({});
     });
 
-    it('should skip already-injected placeholders', () => {
+    it('should update already-injected placeholders with the latest block', () => {
       const ph = makePlaceholder('map-a');
+      const existingRef = makeFakeComponentRef();
       const refs = new Map<HTMLElement, ComponentRef<LeafletMapComponent>>();
-      refs.set(ph, makeFakeComponentRef());
+      refs.set(ph, existingRef);
 
       const stats = service.runInjectionPass({
         placeholders: [ph],
@@ -367,8 +369,11 @@ describe('LeafletInjectionService', () => {
       });
 
       expect(createSpy).not.toHaveBeenCalled();
+      expect(existingRef.setInput).toHaveBeenCalledWith('block', BLOCK_A);
+      expect(existingRef.changeDetectorRef.detectChanges).toHaveBeenCalled();
       expect(stats.created).toBe(0);
-      expect(stats.ignored['already-injected']).toBe(1);
+      expect(stats.updated).toBe(1);
+      expect(stats.ignored['already-injected']).toBeUndefined();
     });
 
     it('should skip placeholders with dataset flag but no ref', () => {
@@ -385,6 +390,7 @@ describe('LeafletInjectionService', () => {
       });
 
       expect(createSpy).not.toHaveBeenCalled();
+      expect(stats.updated).toBe(0);
       expect(stats.ignored['dataset-already-injected']).toBe(1);
     });
 
@@ -401,6 +407,7 @@ describe('LeafletInjectionService', () => {
       });
 
       expect(createSpy).not.toHaveBeenCalled();
+      expect(stats.updated).toBe(0);
       expect(stats.ignored['missing-block:map-unknown']).toBe(1);
     });
 
@@ -423,7 +430,8 @@ describe('LeafletInjectionService', () => {
       expect(createSpy).toHaveBeenCalledTimes(1);
       expect(stats.found).toBe(3);
       expect(stats.created).toBe(1);
-      expect(stats.ignored['already-injected']).toBe(1);
+      expect(stats.updated).toBe(1);
+      expect(stats.ignored['already-injected']).toBeUndefined();
       expect(stats.ignored['missing-block:map-missing']).toBe(1);
       expect(stats.active).toBe(2); // phDup (pre-existing) + phFresh (new)
     });
@@ -466,6 +474,7 @@ describe('LeafletInjectionService', () => {
       });
 
       expect(stats.created).toBe(0);
+      expect(stats.updated).toBe(0);
       expect(stats.ignored['component-creation-failed']).toBe(1);
       expect(log.error).toHaveBeenCalledWith(
         'component-injection-failed',
@@ -487,7 +496,7 @@ describe('LeafletInjectionService', () => {
 
       expect(log.info).toHaveBeenCalledWith(
         'injection-pass',
-        expect.objectContaining({ found: 1, created: 1, active: 1 })
+        expect.objectContaining({ found: 1, created: 1, updated: 0, active: 1 })
       );
     });
 
@@ -504,6 +513,7 @@ describe('LeafletInjectionService', () => {
 
       expect(stats.found).toBe(0);
       expect(stats.created).toBe(0);
+      expect(stats.updated).toBe(0);
       expect(stats.active).toBe(0);
       expect(stats.ignored).toEqual({});
     });

--- a/apps/site/src/_tests/viewer.component.test.ts
+++ b/apps/site/src/_tests/viewer.component.test.ts
@@ -1,0 +1,262 @@
+import { provideLocationMocks } from '@angular/common/testing';
+import { Component, PLATFORM_ID, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { defaultManifest, type Manifest } from '@core-domain';
+import type { LeafletBlock } from '@core-domain/entities/leaflet-block';
+
+import { CatalogFacade } from '../application/facades/catalog-facade';
+import { CONTENT_REPOSITORY } from '../domain/ports/tokens';
+import { OfflineDetectionService, VisitedPagesService } from '../infrastructure/offline';
+import { AnchorScrollService } from '../presentation/services/anchor-scroll.service';
+import { LeafletInjectionService } from '../presentation/services/leaflet-injection.service';
+import { ViewerComponent } from '../presentation/pages/viewer/viewer.component';
+
+jest.mock('../application/facades/catalog-facade', () => ({
+  CatalogFacade: class MockCatalogFacade {},
+}));
+
+@Component({ standalone: true, template: '' })
+class DummyRouteComponent {}
+
+const mathPageHtml = `
+  <div class="markdown-body">
+    <p>Avant</p>
+    <span class="katex-display">
+      <span class="katex">
+        <span class="katex-html" aria-hidden="true">
+          <span class="base">
+            <span class="mord text"><span class="mord textrm">DD psionique</span></span>
+          </span>
+        </span>
+      </span>
+    </span>
+    <p>Apres</p>
+  </div>
+`;
+
+const secondMathPageHtml = `
+  <div class="markdown-body">
+    <p>Equation</p>
+    <span class="katex"><span class="katex-html" aria-hidden="true">E=mc^2</span></span>
+  </div>
+`;
+
+const leafletPageHtml = `
+  <div class="markdown-body">
+    <div data-leaflet-map-id="Ektaron-map"></div>
+  </div>
+`;
+
+function createLeafletBlock(path: string): LeafletBlock {
+  return {
+    id: 'Ektaron-map',
+    imageOverlays: [
+      {
+        path,
+        topLeft: [0, 0],
+        bottomRight: [100, 100],
+      },
+    ],
+  };
+}
+
+function createManifest(): Manifest {
+  return {
+    ...defaultManifest,
+    pages: [
+      {
+        title: 'Math Note',
+        route: '/math-note',
+        slug: 'math-note',
+        lastUpdatedAt: '',
+      },
+      {
+        title: 'Math Note 2',
+        route: '/math-note-2',
+        slug: 'math-note-2',
+        lastUpdatedAt: '',
+      },
+      {
+        title: 'Ektaron',
+        route: '/ektaron',
+        slug: 'ektaron',
+        lastUpdatedAt: '',
+        leafletBlocks: [createLeafletBlock('Ektaron.png')],
+      },
+    ],
+  };
+}
+
+describe('ViewerComponent math HTML rendering', () => {
+  const fetch = jest.fn<Promise<string>, [string]>();
+  const recordVisit = jest.fn();
+  let router: Router;
+  let manifestSignal: ReturnType<typeof signal<Manifest>>;
+  let leafletInjectionService: {
+    canRun: boolean;
+    findPlaceholders: jest.Mock<HTMLElement[], [HTMLElement, string]>;
+    runInjectionPass: jest.Mock;
+    destroyAll: jest.Mock;
+  };
+
+  async function createComponent(platformId: 'browser' | 'server' = 'browser') {
+    fetch.mockImplementation(async (path: string) => {
+      if (path === '/math-note.html') {
+        return mathPageHtml;
+      }
+      if (path === '/math-note-2.html') {
+        return secondMathPageHtml;
+      }
+      if (path === '/ektaron.html') {
+        return leafletPageHtml;
+      }
+      return '<div class="markdown-body"><p>Index</p></div>';
+    });
+
+    manifestSignal = signal(createManifest());
+    leafletInjectionService = {
+      canRun: platformId === 'browser',
+      findPlaceholders: jest.fn((container: HTMLElement, selector: string) =>
+        Array.from(container.querySelectorAll<HTMLElement>(selector))
+      ),
+      runInjectionPass: jest.fn(),
+      destroyAll: jest.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ViewerComponent, DummyRouteComponent],
+      providers: [
+        provideRouter([
+          { path: '', component: DummyRouteComponent },
+          { path: 'math-note', component: DummyRouteComponent },
+          { path: 'math-note-2', component: DummyRouteComponent },
+          { path: 'ektaron', component: DummyRouteComponent },
+        ]),
+        provideLocationMocks(),
+        { provide: PLATFORM_ID, useValue: platformId },
+        { provide: CONTENT_REPOSITORY, useValue: { fetch } },
+        { provide: CatalogFacade, useValue: { manifest: manifestSignal } },
+        { provide: LeafletInjectionService, useValue: leafletInjectionService },
+        { provide: VisitedPagesService, useValue: { recordVisit } },
+        { provide: OfflineDetectionService, useValue: { isOffline: false } },
+        {
+          provide: AnchorScrollService,
+          useValue: {
+            navigateToAnchor: jest.fn().mockResolvedValue(undefined),
+            isCurrentPageLink: jest.fn().mockReturnValue(false),
+            scrollToAnchor: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    const fixture = TestBed.createComponent(ViewerComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    TestBed.resetTestingModule();
+  });
+
+  it('injects KaTeX HTML produced by the backend without client-side math rendering', async () => {
+    const fixture = await createComponent();
+
+    await router.navigateByUrl('/math-note');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const host: HTMLElement = fixture.nativeElement;
+    expect(fetch).toHaveBeenCalledWith('/math-note.html');
+    expect(host.querySelector('.katex-display')).toBeTruthy();
+    expect(host.textContent).toContain('DD psionique');
+    expect(host.textContent).toContain('Avant');
+    expect(host.textContent).toContain('Apres');
+  });
+
+  it('keeps math HTML stable after route navigation and component recreation', async () => {
+    const fixture = await createComponent();
+
+    await router.navigateByUrl('/math-note');
+    await fixture.whenStable();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.katex-display')).toBeTruthy();
+
+    await router.navigateByUrl('/math-note-2');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fetch).toHaveBeenCalledWith('/math-note-2.html');
+    expect(fixture.nativeElement.querySelector('.katex-display')).toBeFalsy();
+    expect(fixture.nativeElement.querySelector('.katex')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toContain('E=mc^2');
+
+    fixture.destroy();
+
+    TestBed.resetTestingModule();
+    const recreatedFixture = await createComponent();
+    await router.navigateByUrl('/math-note');
+    await recreatedFixture.whenStable();
+    recreatedFixture.detectChanges();
+
+    expect(recreatedFixture.nativeElement.querySelector('.katex-display')).toBeTruthy();
+    expect(recreatedFixture.nativeElement.textContent).toContain('DD psionique');
+  });
+
+  it('does not introduce an obvious SSR regression when the viewer runs on the server platform', async () => {
+    const fixture = await createComponent('server');
+
+    await router.navigateByUrl('/math-note');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fetch).toHaveBeenCalledWith('/math-note.html');
+    expect(fixture.nativeElement.querySelector('.katex-display')).toBeTruthy();
+  });
+
+  it('re-injects Leaflet with updated manifest data when the current page blocks change', async () => {
+    const fixture = await createComponent();
+
+    await router.navigateByUrl('/ektaron');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fetch).toHaveBeenCalledWith('/ektaron.html');
+    expect(leafletInjectionService.runInjectionPass).toHaveBeenCalled();
+
+    manifestSignal.update((manifest) => ({
+      ...manifest,
+      pages: manifest.pages.map((page) =>
+        page.route === '/ektaron'
+          ? {
+              ...page,
+              leafletBlocks: [createLeafletBlock('Ektaron.webp')],
+            }
+          : page
+      ),
+    }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const lastCall =
+      leafletInjectionService.runInjectionPass.mock.calls[
+        leafletInjectionService.runInjectionPass.mock.calls.length - 1
+      ]?.[0];
+    const placeholder = fixture.nativeElement.querySelector('[data-leaflet-map-id="Ektaron-map"]');
+    const resolution = lastCall.resolveBlock(placeholder);
+
+    expect(leafletInjectionService.runInjectionPass.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(resolution).toEqual(
+      expect.objectContaining({
+        ok: true,
+        mapId: 'Ektaron-map',
+        block: expect.objectContaining({
+          imageOverlays: [expect.objectContaining({ path: 'Ektaron.webp' })],
+        }),
+      })
+    );
+  });
+});

--- a/apps/site/src/application/facades/catalog-facade.ts
+++ b/apps/site/src/application/facades/catalog-facade.ts
@@ -1,16 +1,19 @@
-import { computed, Inject, Injectable, signal } from '@angular/core';
+import { computed, Inject, Injectable, Optional, signal } from '@angular/core';
 import { FindPageHandler, LoadManifestHandler, SearchPagesHandler } from '@core-application';
 import type { Manifest, ManifestPage, ManifestRepository } from '@core-domain';
 import { defaultManifest } from '@core-domain';
+import { Subject, takeUntil } from 'rxjs';
 
 import type { ContentRepository } from '../../domain/ports/content-repository.port';
 import { CONTENT_REPOSITORY, MANIFEST_REPOSITORY } from '../../domain/ports/tokens';
+import { ContentVersionService } from '../../infrastructure/content-version/content-version.service';
 
 @Injectable({ providedIn: 'root' })
 export class CatalogFacade {
   private readonly loadManifestQuery: LoadManifestHandler;
   private readonly searchQuery: SearchPagesHandler;
   private readonly findQuery: FindPageHandler;
+  private readonly destroy$ = new Subject<void>();
 
   manifest = signal<Manifest>(defaultManifest);
   query = signal('');
@@ -19,15 +22,23 @@ export class CatalogFacade {
 
   constructor(
     @Inject(MANIFEST_REPOSITORY) private readonly manifestRepository: ManifestRepository,
-    @Inject(CONTENT_REPOSITORY) private readonly contentRepository: ContentRepository
+    @Inject(CONTENT_REPOSITORY) private readonly contentRepository: ContentRepository,
+    @Optional()
+    @Inject(ContentVersionService)
+    private readonly contentVersionService?: Pick<
+      ContentVersionService,
+      'versionChanged$' | 'checkVersion'
+    >
   ) {
     this.loadManifestQuery = new LoadManifestHandler(this.manifestRepository);
-    void this.loadManifestQuery.handle().then((m) => {
-      this.manifest.set(m);
-    });
+    void this.initializeManifest();
 
     this.searchQuery = new SearchPagesHandler();
     this.findQuery = new FindPageHandler();
+
+    this.contentVersionService?.versionChanged$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      void this.ensureManifest();
+    });
   }
 
   results = computed(() => {
@@ -51,6 +62,11 @@ export class CatalogFacade {
     }
   }
 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
   async getHtmlBySlugOrRoute(slugOrRoute: string): Promise<{ title: string; html: string } | null> {
     await this.ensureManifest();
     const m = this.manifest();
@@ -68,5 +84,16 @@ export class CatalogFacade {
     const raw = await this.contentRepository.fetch((page as ManifestPage).route);
 
     return { title: page.title, html: raw };
+  }
+
+  private async initializeManifest(): Promise<void> {
+    try {
+      await this.contentVersionService?.checkVersion?.();
+    } catch {
+      // If version probing fails, still load the manifest.
+    }
+
+    const manifest = await this.loadManifestQuery.handle();
+    this.manifest.set(manifest);
   }
 }

--- a/apps/site/src/infrastructure/content-version/_tests/content-version.interceptor.spec.ts
+++ b/apps/site/src/infrastructure/content-version/_tests/content-version.interceptor.spec.ts
@@ -110,6 +110,17 @@ describe('contentVersionInterceptor', () => {
       req.flush('');
     });
 
+    it('should add cv parameter to published asset requests', () => {
+      httpClient.get('/assets/my-image.png').subscribe();
+
+      const req = httpTestingController.expectOne(
+        (request) =>
+          request.url.startsWith('/assets/my-image.png') && request.url.includes('cv=test-cv-123')
+      );
+      expect(req.request.url).toBe('/assets/my-image.png?cv=test-cv-123');
+      req.flush('');
+    });
+
     it('should NOT add cv parameter if already present', () => {
       httpClient.get('/content/_manifest.json?cv=existing').subscribe();
 

--- a/apps/site/src/infrastructure/content-version/content-version.interceptor.ts
+++ b/apps/site/src/infrastructure/content-version/content-version.interceptor.ts
@@ -11,6 +11,7 @@ const VERSIONED_URL_PATTERNS = [
   /^\/content\//,
   /^\/_manifest\.json/,
   /^\/content\/_manifest\.json/,
+  /^\/assets\//,
 ];
 
 /**
@@ -33,8 +34,8 @@ const EXCLUDED_URL_PATTERNS = [
  *
  * @example
  * ```
- * // Before: /content/_manifest.json
- * // After:  /content/_manifest.json?cv=abc123
+ * // Before: /content/_manifest.json      → /content/_manifest.json?cv=abc123
+ * // Before: /assets/map.png               → /assets/map.png?cv=abc123
  * ```
  */
 export const contentVersionInterceptor: HttpInterceptorFn = (req, next) => {

--- a/apps/site/src/presentation/components/leaflet-map/leaflet-map.component.ts
+++ b/apps/site/src/presentation/components/leaflet-map/leaflet-map.component.ts
@@ -13,6 +13,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import type { LeafletBlock } from '@core-domain/entities/leaflet-block';
+import { ContentVersionService } from '../../../infrastructure/content-version/content-version.service';
 
 /**
  * Composant Angular pour afficher une carte Leaflet en mode lecture seule.
@@ -44,6 +45,7 @@ export class LeafletMapComponent implements AfterViewInit, OnDestroy {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly ngZone = inject(NgZone);
   private readonly injector = inject(Injector);
+  private readonly contentVersionService = inject(ContentVersionService);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private map: any = null; // Type 'any' pour éviter l'import de Leaflet côté serveur
   private isBrowser = false;
@@ -520,8 +522,10 @@ export class LeafletMapComponent implements AfterViewInit, OnDestroy {
     const allBounds: [[number, number], [number, number]][] = [];
 
     this.block.imageOverlays?.forEach((overlay) => {
-      // Construire l'URL de l'image via l'API d'assets
-      const imageUrl = `/assets/${overlay.path}`;
+      // Construire l'URL de l'image via l'API d'assets avec cache-busting
+      const cv = this.contentVersionService.currentVersion;
+      const basePath = `/assets/${encodeURI(overlay.path)}`;
+      const imageUrl = cv ? `${basePath}?cv=${encodeURIComponent(cv)}` : basePath;
 
       // Charger l'image pour obtenir ses dimensions réelles
       const img = new Image();

--- a/apps/site/src/presentation/pages/viewer/viewer.component.ts
+++ b/apps/site/src/presentation/pages/viewer/viewer.component.ts
@@ -23,7 +23,17 @@ import { MatTooltip, MatTooltipModule } from '@angular/material/tooltip';
 import { DomSanitizer, type SafeHtml } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 import type { LeafletBlock } from '@core-domain/entities/leaflet-block';
-import { catchError, distinctUntilChanged, filter, from, map, of, switchMap, tap } from 'rxjs';
+import {
+  catchError,
+  distinctUntilChanged,
+  filter,
+  from,
+  map,
+  of,
+  startWith,
+  switchMap,
+  tap,
+} from 'rxjs';
 
 import { CatalogFacade } from '../../../application/facades/catalog-facade';
 import { CONTENT_REPOSITORY } from '../../../domain/ports/tokens';
@@ -81,35 +91,20 @@ export class ViewerComponent implements OnDestroy {
   // Flux réactif moderne avec toSignal (Angular 20 pattern)
   private readonly rawHtml = toSignal(
     this.router.events.pipe(
+      startWith(null),
       map(() => this.router.url.split('?')[0].split('#')[0]),
       distinctUntilChanged(),
       switchMap((routePath) => {
-        const normalized = routePath.replace(/\/+$/, '') || '/';
+        const normalized = this.normalizeRoute(routePath);
         const htmlUrl = normalized === '/' ? '/index.html' : `${normalized}.html`;
-        const manifest = this.catalog.manifest();
 
         // Update currentRoute for breadcrumbs
         this.currentRoute.set(normalized);
 
-        let pageTitle = '';
-        if (manifest.pages.length > 0) {
-          const p = manifest.pages.find((x) => x.route === normalized);
-          if (p) {
-            pageTitle = this.capitalize(p.title) ?? '';
-            this.title.set(pageTitle);
-            // Mettre à jour les blocs Leaflet si présents
-            const leafletBlocks = p.leafletBlocks ?? [];
-            this.leafletBlocks.set(leafletBlocks);
-          } else {
-            this.leafletBlocks.set([]);
-          }
-        } else {
-          this.leafletBlocks.set([]);
-        }
-
         return from(this.contentRepository.fetch(htmlUrl)).pipe(
           tap(() => {
             // Record successful page visit for offline access
+            const pageTitle = this.title();
             if (pageTitle && normalized !== '/') {
               this.visitedPagesService.recordVisit(normalized.slice(1), pageTitle, normalized);
             }
@@ -147,9 +142,25 @@ export class ViewerComponent implements OnDestroy {
     private readonly catalog: CatalogFacade,
     private readonly environmentInjector: EnvironmentInjector
   ) {
+    effect(() => {
+      const manifest = this.catalog.manifest();
+      const route = this.currentRoute();
+      const page = manifest.pages.find((candidate) => candidate.route === route);
+
+      if (!page) {
+        this.title.set('');
+        this.leafletBlocks.set([]);
+        return;
+      }
+
+      this.title.set(this.capitalize(page.title) ?? '');
+      this.leafletBlocks.set(page.leafletBlocks ?? []);
+    });
+
     // Effect pour décorer le DOM après chargement
     effect(() => {
       this.html();
+      this.leafletBlocks();
       const cycle = ++this.postRenderCycle;
       afterNextRender(
         () => {
@@ -184,6 +195,10 @@ export class ViewerComponent implements OnDestroy {
 
   private capitalize(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1);
+  }
+
+  private normalizeRoute(routePath: string): string {
+    return routePath.replace(/\/+$/, '') || '/';
   }
 
   private decorateWikilinks(): void {

--- a/apps/site/src/presentation/services/leaflet-injection.service.ts
+++ b/apps/site/src/presentation/services/leaflet-injection.service.ts
@@ -19,6 +19,7 @@ import { LeafletMapComponent } from '../components/leaflet-map/leaflet-map.compo
 export interface LeafletInjectionStats {
   found: number;
   created: number;
+  updated: number;
   active: number;
   ignored: Record<string, number>;
 }
@@ -105,6 +106,21 @@ export class LeafletInjectionService {
     });
   }
 
+  updateLeafletComponent(
+    placeholder: HTMLElement,
+    block: LeafletBlock,
+    refs: Map<HTMLElement, ComponentRef<LeafletMapComponent>>
+  ): boolean {
+    const componentRef = refs.get(placeholder);
+    if (!componentRef) {
+      return false;
+    }
+
+    componentRef.setInput('block', block);
+    componentRef.changeDetectorRef.detectChanges();
+    return true;
+  }
+
   // -----------------------------------------------------------------------
   // Stale reference cleanup
   // -----------------------------------------------------------------------
@@ -162,6 +178,7 @@ export class LeafletInjectionService {
     const stats: LeafletInjectionStats = {
       found: placeholders.length,
       created: 0,
+      updated: 0,
       active: refs.size,
       ignored: {},
     };
@@ -170,13 +187,26 @@ export class LeafletInjectionService {
       const mapId = placeholder.dataset['leafletMapId'] ?? 'unknown-map';
       log.info('placeholder-found', { mapId });
 
+      const resolution = resolveBlock(placeholder);
+
+      if (refs.has(placeholder)) {
+        if (!resolution.ok) {
+          incrementReason(stats.ignored, resolution.reason);
+          continue;
+        }
+
+        this.updateLeafletComponent(placeholder, resolution.block, refs);
+        stats.updated++;
+        log.info('component-updated', { mapId: resolution.mapId, category: 'timing' });
+        continue;
+      }
+
       const skipReason = this.getSkipReason(placeholder, refs);
       if (skipReason) {
         incrementReason(stats.ignored, skipReason);
         continue;
       }
 
-      const resolution = resolveBlock(placeholder);
       if (!resolution.ok) {
         incrementReason(stats.ignored, resolution.reason);
         continue;

--- a/apps/site/src/styles.scss
+++ b/apps/site/src/styles.scss
@@ -3,6 +3,7 @@
 
 // Import Leaflet CSS for map rendering
 @import 'leaflet/dist/leaflet.css';
+@import 'katex/dist/katex.min.css';
 
 // Note: Roboto fonts are now loaded via index.html with preload for better LCP
 // The font-family is already set in the ITS theme via --font-family-default
@@ -169,6 +170,12 @@ samp,
     'wght' 400,
     'GRAD' 0,
     'opsz' 24;
+}
+
+.katex-display {
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-block: 0.125rem;
 }
 
 /* Images: Contraste automatique global selon le thème */

--- a/docs/plugin/syntaxes.md
+++ b/docs/plugin/syntaxes.md
@@ -219,6 +219,28 @@ for (const page of pages) {
 
 → Toutes les requêtes sont **exécutées côté plugin** et rendues en HTML avant upload.
 
+## Maths & LaTeX
+
+Les expressions mathématiques Obsidian sont rendues **côté backend** avec **KaTeX** avant d’être servies par le site. Le frontend Angular ne recalcule pas la formule: il injecte simplement le HTML généré, ce qui reste compatible avec SSR/hydratation.
+
+### Blocs `$$ ... $$`
+
+```markdown
+$$
+\textnormal{DD psionique} = 8 + \textnormal{bonus de maîtrise} + \textnormal{modificateur de caractéristique}
+$$
+```
+
+→ Le HTML final contient le markup KaTeX prêt à afficher.
+
+### Inline `$...$`
+
+```markdown
+Énergie : $E = mc^2$
+```
+
+→ Le rendu inline est aussi supporté dans le texte courant.
+
 ## Cartes Leaflet
 
 Les blocs ` ```leaflet ` sont détectés, parsés et remplacés par des placeholders HTML. Le rendu interactif se fait côté client sur le site publié.

--- a/libs/core-application/src/lib/_tests/publishing/asset-deduplication.test.ts
+++ b/libs/core-application/src/lib/_tests/publishing/asset-deduplication.test.ts
@@ -107,7 +107,7 @@ describe('Asset Deduplication (B4)', () => {
       // Asset should be skipped (not uploaded)
       expect(result.published).toBe(0);
       expect(result.skipped).toBe(1);
-      expect(result.skippedAssets).toEqual(['_assets/duplicate-image.png']);
+      expect(result.skippedAssets).toEqual(['_assets/existing-image.png']);
       expect(storage.save).not.toHaveBeenCalled();
 
       // But manifest should be updated with the asset still present

--- a/libs/core-application/src/lib/_tests/publishing/handlers/upload-assets.handler.test.ts
+++ b/libs/core-application/src/lib/_tests/publishing/handlers/upload-assets.handler.test.ts
@@ -1,8 +1,15 @@
-import { type LoggerPort } from '@core-domain';
+import {
+  type AssetHashPort,
+  type AssetValidatorPort,
+  type ImageOptimizerPort,
+  type LoggerPort,
+  type ManifestAsset,
+} from '@core-domain';
 
 import { type UploadAssetsCommand } from '../../../publishing/commands/upload-assets.command';
 import { UploadAssetsHandler } from '../../../publishing/handlers/upload-assets.handler';
 import { type AssetStoragePort } from '../../../publishing/ports/assets-storage.port';
+import { type ManifestPort } from '../../../publishing/ports/manifest-storage.port';
 
 describe('UploadAssetsHandler', () => {
   let assetStorage: { upload: jest.Mock<any, any> } & jest.Mocked<AssetStoragePort>;
@@ -98,5 +105,385 @@ describe('UploadAssetsHandler', () => {
       debug: jest.fn(),
     } as any;
     expect(() => new UploadAssetsHandler(assetStorage, customLogger)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dedup-skipped assets must propagate renamedAssets when the published
+// path on disk differs from the source filename sent by the plugin.
+// ---------------------------------------------------------------------------
+
+describe('UploadAssetsHandler – dedup-skipped asset path mapping', () => {
+  function makeLogger(): jest.Mocked<LoggerPort> {
+    const l: any = {
+      child: jest.fn().mockReturnThis(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    return l;
+  }
+
+  function makeStorage(): jest.Mocked<AssetStoragePort> {
+    return { save: jest.fn().mockResolvedValue(undefined) } as any;
+  }
+
+  function makeHasher(hash: string): jest.Mocked<AssetHashPort> {
+    return { computeHash: jest.fn().mockResolvedValue(hash) };
+  }
+
+  function makeManifest(assets: ManifestAsset[]): jest.Mocked<ManifestPort> {
+    return {
+      load: jest.fn().mockResolvedValue({
+        sessionId: 'prev',
+        createdAt: new Date(),
+        lastUpdatedAt: new Date(),
+        pages: [],
+        assets,
+      }),
+      save: jest.fn().mockResolvedValue(undefined),
+    } as any;
+  }
+
+  it('should produce renamedAssets when dedup-skipped asset has a different published path', async () => {
+    // Scenario: previous publication optimised Ektaron.png → Ektaron.webp.
+    // New publication sends the same content (same hash after optimisation).
+    // The handler should map "Ektaron.png" → "Ektaron.webp" for path rewriting.
+    const existingAsset: ManifestAsset = {
+      path: 'Ektaron.webp',
+      hash: 'abc123',
+      size: 1000,
+      mimeType: 'image/webp',
+      uploadedAt: new Date(),
+    };
+
+    const handler = new UploadAssetsHandler(
+      makeStorage(),
+      makeManifest([existingAsset]),
+      makeHasher('abc123'), // same hash → dedup will fire
+      undefined, // no validator
+      undefined, // no size limit
+      undefined, // no optimizer (already deduped before optimizer would run — or optimizer produces same hash)
+      makeLogger()
+    );
+
+    const result = await handler.handle({
+      sessionId: 's1',
+      assets: [
+        {
+          relativePath: 'Ektaron.png',
+          vaultPath: '_assets/Ektaron.png',
+          fileName: 'Ektaron.png',
+          mimeType: 'image/png',
+          contentBase64: Buffer.from('fake-png-content').toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.renamedAssets).toEqual({ 'Ektaron.png': 'Ektaron.webp' });
+    expect(result.published).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it('should NOT produce renamedAssets when dedup-skipped asset has the same path', async () => {
+    const existingAsset: ManifestAsset = {
+      path: 'icon.svg',
+      hash: 'def456',
+      size: 500,
+      mimeType: 'image/svg+xml',
+      uploadedAt: new Date(),
+    };
+
+    const handler = new UploadAssetsHandler(
+      makeStorage(),
+      makeManifest([existingAsset]),
+      makeHasher('def456'),
+      undefined,
+      undefined,
+      undefined,
+      makeLogger()
+    );
+
+    const result = await handler.handle({
+      sessionId: 's2',
+      assets: [
+        {
+          relativePath: 'icon.svg',
+          vaultPath: '_assets/icon.svg',
+          fileName: 'icon.svg',
+          mimeType: 'image/svg+xml',
+          contentBase64: Buffer.from('fake-svg').toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.renamedAssets).toBeUndefined();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('should produce renamedAssets for dedup-skipped assets with subfolder path differences', async () => {
+    const existingAsset: ManifestAsset = {
+      path: 'maps/world.webp',
+      hash: 'hash789',
+      size: 2000,
+      mimeType: 'image/webp',
+      uploadedAt: new Date(),
+    };
+
+    const handler = new UploadAssetsHandler(
+      makeStorage(),
+      makeManifest([existingAsset]),
+      makeHasher('hash789'),
+      undefined,
+      undefined,
+      undefined,
+      makeLogger()
+    );
+
+    const result = await handler.handle({
+      sessionId: 's3',
+      assets: [
+        {
+          relativePath: 'maps/world.png',
+          vaultPath: '_assets/maps/world.png',
+          fileName: 'world.png',
+          mimeType: 'image/png',
+          contentBase64: Buffer.from('fake-map').toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.renamedAssets).toEqual({ 'maps/world.png': 'maps/world.webp' });
+  });
+
+  it('should prefer existing published path over current optimizer output', async () => {
+    // Previous publication converted Banner.png → Banner.webp.
+    // Current session's optimizer is now configured for AVIF,
+    // but the content hash still matches the existing .webp asset.
+    // The handler MUST use the on-disk path (.webp), NOT the optimizer output (.avif).
+    const existingAsset: ManifestAsset = {
+      path: 'Banner.webp',
+      hash: 'same-hash',
+      size: 900,
+      mimeType: 'image/webp',
+      uploadedAt: new Date(),
+    };
+
+    const mockOptimizer: ImageOptimizerPort = {
+      isOptimizable: jest.fn().mockReturnValue(true),
+      optimize: jest.fn().mockResolvedValue({
+        data: new Uint8Array(Buffer.from('avif-bytes')),
+        format: 'avif',
+        originalFilename: 'Banner.png',
+        optimizedFilename: 'Banner.avif',
+        originalSize: 2000,
+        optimizedSize: 800,
+        width: 100,
+        height: 100,
+        wasOptimized: true,
+      }),
+      getConfig: jest.fn(),
+    };
+
+    const handler = new UploadAssetsHandler(
+      makeStorage(),
+      makeManifest([existingAsset]),
+      makeHasher('same-hash'),
+      undefined,
+      undefined,
+      mockOptimizer,
+      makeLogger()
+    );
+
+    const result = await handler.handle({
+      sessionId: 's-opt',
+      assets: [
+        {
+          relativePath: 'Banner.png',
+          vaultPath: '_assets/Banner.png',
+          fileName: 'Banner.png',
+          mimeType: 'image/png',
+          contentBase64: Buffer.from('raw-banner').toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.renamedAssets).toEqual({ 'Banner.png': 'Banner.webp' });
+    expect(result.published).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+
+  it('should return no renamedAssets when no assets are provided', async () => {
+    const handler = new UploadAssetsHandler(
+      makeStorage(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      makeLogger()
+    );
+
+    const result = await handler.handle({ sessionId: 's-empty', assets: [] });
+
+    expect(result.renamedAssets).toBeUndefined();
+    expect(result.published).toBe(0);
+    expect(result.skipped).toBeUndefined();
+  });
+});
+
+describe('UploadAssetsHandler - optimized image size validation', () => {
+  function makeLogger(): jest.Mocked<LoggerPort> {
+    const l: any = {
+      child: jest.fn().mockReturnThis(),
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    return l;
+  }
+
+  function makeStorage(): jest.Mocked<AssetStoragePort> {
+    return { save: jest.fn().mockResolvedValue(undefined) } as any;
+  }
+
+  it('should validate optimizable images against the final optimized size', async () => {
+    const storage = makeStorage();
+    const validator: jest.Mocked<AssetValidatorPort> = {
+      validate: jest
+        .fn()
+        .mockImplementationOnce(async (buffer, filename, clientMimeType, maxSizeBytes) => {
+          expect(filename).toBe('Ektaron.png');
+          expect(clientMimeType).toBe('image/png');
+          expect(maxSizeBytes).toBeUndefined();
+          return {
+            valid: true,
+            detectedMimeType: 'image/png',
+            sizeBytes: buffer.length,
+          };
+        })
+        .mockImplementationOnce(async (buffer, filename, clientMimeType, maxSizeBytes) => {
+          expect(filename).toBe('Ektaron.webp');
+          expect(clientMimeType).toBe('image/webp');
+          expect(maxSizeBytes).toBe(10);
+          return {
+            valid: true,
+            detectedMimeType: 'image/webp',
+            sizeBytes: buffer.length,
+          };
+        }),
+    };
+    const optimizer: jest.Mocked<ImageOptimizerPort> = {
+      isOptimizable: jest.fn().mockReturnValue(true),
+      optimize: jest.fn().mockResolvedValue({
+        data: new Uint8Array(Buffer.alloc(5)),
+        format: 'webp',
+        originalFilename: 'Ektaron.png',
+        optimizedFilename: 'Ektaron.webp',
+        originalSize: 20,
+        optimizedSize: 5,
+        width: 100,
+        height: 100,
+        wasOptimized: true,
+      }),
+      getConfig: jest.fn(),
+    };
+
+    const handler = new UploadAssetsHandler(
+      storage,
+      undefined,
+      undefined,
+      validator,
+      10,
+      optimizer,
+      makeLogger()
+    );
+
+    const result = await handler.handle({
+      sessionId: 's-image-ok',
+      assets: [
+        {
+          relativePath: 'Ektaron.png',
+          vaultPath: '_assets/Ektaron.png',
+          fileName: 'Ektaron.png',
+          mimeType: 'image/png',
+          contentBase64: Buffer.alloc(20).toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.published).toBe(1);
+    expect(result.errors).toBeUndefined();
+    expect(result.renamedAssets).toEqual({ 'Ektaron.png': 'Ektaron.webp' });
+    expect(storage.save).toHaveBeenCalledWith([
+      { filename: 'Ektaron.webp', content: Buffer.alloc(5) },
+    ]);
+    expect(validator.validate).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject optimizable images when the optimized output still exceeds the size limit', async () => {
+    const storage = makeStorage();
+    const validator: jest.Mocked<AssetValidatorPort> = {
+      validate: jest
+        .fn()
+        .mockImplementationOnce(async (buffer) => ({
+          valid: true,
+          detectedMimeType: 'image/png',
+          sizeBytes: buffer.length,
+        }))
+        .mockImplementationOnce(async () => {
+          throw new Error('Asset size 15 bytes exceeds maximum allowed 10 bytes');
+        }),
+    };
+    const optimizer: jest.Mocked<ImageOptimizerPort> = {
+      isOptimizable: jest.fn().mockReturnValue(true),
+      optimize: jest.fn().mockResolvedValue({
+        data: new Uint8Array(Buffer.alloc(15)),
+        format: 'webp',
+        originalFilename: 'Ektaron.png',
+        optimizedFilename: 'Ektaron.webp',
+        originalSize: 20,
+        optimizedSize: 15,
+        width: 100,
+        height: 100,
+        wasOptimized: true,
+      }),
+      getConfig: jest.fn(),
+    };
+
+    const handler = new UploadAssetsHandler(
+      storage,
+      undefined,
+      undefined,
+      validator,
+      10,
+      optimizer,
+      makeLogger()
+    );
+
+    const result = await handler.handle({
+      sessionId: 's-image-too-large',
+      assets: [
+        {
+          relativePath: 'Ektaron.png',
+          vaultPath: '_assets/Ektaron.png',
+          fileName: 'Ektaron.png',
+          mimeType: 'image/png',
+          contentBase64: Buffer.alloc(20).toString('base64'),
+        },
+      ],
+    });
+
+    expect(result.published).toBe(0);
+    expect(result.errors).toEqual([
+      {
+        assetName: 'Ektaron.png',
+        message: 'Asset size 15 bytes exceeds maximum allowed 10 bytes',
+      },
+    ]);
+    expect(storage.save).not.toHaveBeenCalled();
+    expect(validator.validate).toHaveBeenCalledTimes(2);
   });
 });

--- a/libs/core-application/src/lib/publishing/handlers/upload-assets.handler.ts
+++ b/libs/core-application/src/lib/publishing/handlers/upload-assets.handler.ts
@@ -86,14 +86,18 @@ export class UploadAssetsHandler implements CommandHandler<
           const filename = asset.relativePath || asset.fileName;
           let content = this.decodeBase64(asset.contentBase64);
           let finalFilename = filename;
+          const isOptimizableImage =
+            !!this.imageOptimizer && this.imageOptimizer.isOptimizable(filename);
 
-          // Validate asset (size + real MIME detection) if validator is configured
+          // Validate original asset before any transformation.
+          // For optimizable images, defer the size limit check until after optimization
+          // so large source files can still be accepted if the published asset fits.
           if (this.assetValidator) {
             const validationResult = await this.assetValidator.validate(
               content,
               filename,
               asset.mimeType,
-              this.maxAssetSizeBytes
+              isOptimizableImage ? undefined : this.maxAssetSizeBytes
             );
 
             // Replace client MIME with detected MIME for security
@@ -107,7 +111,7 @@ export class UploadAssetsHandler implements CommandHandler<
           }
 
           // Optimize image if optimizer is configured and image is optimizable
-          if (this.imageOptimizer && this.imageOptimizer.isOptimizable(filename)) {
+          if (isOptimizableImage && this.imageOptimizer) {
             try {
               const originalSize = content.length;
               const optimized = await this.imageOptimizer.optimize(content, filename);
@@ -133,6 +137,25 @@ export class UploadAssetsHandler implements CommandHandler<
             }
           }
 
+          // Validate the published image after optimization so the enforced size limit
+          // applies to the actual file written to disk.
+          if (this.assetValidator && isOptimizableImage) {
+            const validationResult = await this.assetValidator.validate(
+              content,
+              finalFilename,
+              asset.mimeType,
+              this.maxAssetSizeBytes
+            );
+
+            asset.mimeType = validationResult.detectedMimeType;
+
+            this._logger?.debug('Optimized asset validated', {
+              filename: finalFilename,
+              sizeBytes: validationResult.sizeBytes,
+              detectedMimeType: validationResult.detectedMimeType,
+            });
+          }
+
           // Compute hash for deduplication (if hasher is available)
           const hash = this.assetHasher ? await this.assetHasher.computeHash(content) : undefined;
 
@@ -140,14 +163,22 @@ export class UploadAssetsHandler implements CommandHandler<
           if (hash) {
             const existingAsset = existingAssetsByHash.get(hash);
             if (existingAsset) {
+              // Use the path actually stored on disk (existingAsset.path) as the
+              // authoritative final name. This covers the case where a previous
+              // publication optimised the file (e.g. .png → .webp) and the current
+              // session deduplicates it: the mapping must still propagate so that
+              // Leaflet overlay paths and other HTML references are rewritten.
+              const publishedPath = existingAsset.path;
+
               this._logger?.info('Asset already exists (duplicate hash), skipping upload', {
                 filename: finalFilename,
                 hash,
-                existingPath: existingAsset.path,
+                existingPath: publishedPath,
+                publishedPathDiffersFromSource: filename !== publishedPath,
               });
               // Add existing asset to staged manifest (preserve reference)
               allStagedAssets.push(existingAsset);
-              return { originalFilename: filename, finalFilename, skipped: true };
+              return { originalFilename: filename, finalFilename: publishedPath, skipped: true };
             }
           }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "express": "^4.19.2",
         "file-type": "16.5.4",
         "jsdom": "^20.0.3",
+        "katex": "^0.16.38",
         "leaflet": "^1.9.4",
         "leaflet.fullscreen": "^5.1.1",
         "markdown-it": "^14.1.0",
@@ -35777,6 +35778,31 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.38",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.38.tgz",
+      "integrity": "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/keygrip": {

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "express": "^4.19.2",
     "file-type": "16.5.4",
     "jsdom": "^20.0.3",
+    "katex": "^0.16.38",
     "leaflet": "^1.9.4",
     "leaflet.fullscreen": "^5.1.1",
     "markdown-it": "^14.1.0",


### PR DESCRIPTION
## Summary

This PR improves the published site pipeline by fixing several issues affecting rendered content, asset delivery, and post-publication consistency.

## Changes

- render published math expressions with KaTeX
- harden optimized asset publishing so publish-time validation matches the final optimized output
- resolve Dataview-generated wikilinks during session finalization, when the final manifest is available
- refresh published assets more reliably with shorter cache headers and updated client refresh behavior
- fix Leaflet asset refresh issues after publication updates
- align related tests with the current asset deduplication behavior and stabilize the optimized asset integration test

## Why

These changes address multiple production issues observed after publication:
- broken or stale Leaflet overlays due to asset refresh/cache behavior
- incorrect or unresolved links generated from Dataview blocks
- asset publication inconsistencies when optimization changes the final file size
- missing math rendering on published pages
